### PR TITLE
fix: Tool fixes, f-string handling, and validated examples

### DIFF
--- a/examples/static_structural_workflow.md
+++ b/examples/static_structural_workflow.md
@@ -2,7 +2,10 @@
 
 This example demonstrates a complete Mechanical FEA workflow using the
 pymechanical-mcp tools. All steps were validated live against
-ANSYS Mechanical 2025 R2.
+ANSYS Mechanical 2025 R2 on April 21, 2026.
+
+> **GUI Mode:** Launch Mechanical with `batch=false` so the GUI is visible
+> and you can see geometry, mesh, and result contour plots interactively.
 
 ## 1. Check Mechanical Installation
 
@@ -12,9 +15,16 @@ ANSYS Mechanical 2025 R2.
 Response: Mechanical is installed on this system.
 ```
 
-## 2. Launch Mechanical
+## 2. Launch Mechanical (GUI Mode)
 
 **Tool:** `launch_mechanical`
+
+| Parameter | Value |
+|-----------|-------|
+| batch     | false |
+
+> Set `batch=false` to launch Mechanical in interactive/GUI mode.
+> The Mechanical window will be visible on the desktop.
 
 ```
 Response:
@@ -61,9 +71,11 @@ Response: Static Structural analysis added: Static Structural
 
 **Tool:** `run_python_script`
 
+> Replace the file path with your actual STEP/IGES geometry file.
+
 ```python
 geometry_import = Model.GeometryImportGroup.AddGeometryImport()
-geometry_file = r"C:\path\to\your\model.step"
+geometry_file = r"D:\ANSYS-DEV\models\simple_beam.step"
 geometry_import_format = Ansys.Mechanical.DataModel.Enums.GeometryImportPreference.Format.Automatic
 geometry_import_prefs = Ansys.ACT.Mechanical.Utilities.GeometryImportPreferences()
 geometry_import_prefs.ProcessNamedSelections = True
@@ -74,66 +86,134 @@ geometry_import.Import(geometry_file, geometry_import_format, geometry_import_pr
 ```
 
 ```
-Response: Geometry imported: 3 bodies
+Response: Geometry imported: 1 bodies
 ```
 
-## 6. Generate Mesh
+## 6. Assign Material
 
 **Tool:** `run_python_script`
 
 ```python
+body = Model.Geometry.GetChildren(DataModelObjectCategory.Body, True)[0]
+body.Material = "Structural Steel"
+"Material assigned: {0}".format(body.Material)
+```
+
+```
+Response: Material assigned: Structural Steel
+```
+
+## 7. Generate Mesh
+
+**Tool:** `run_python_script`
+
+> **Unit format:** Use `Quantity("5 [mm]")` with square brackets for Mechanical.
+
+```python
 mesh = Model.Mesh
+mesh.ElementSize = Quantity("5 [mm]")
 mesh.GenerateMesh()
 "Mesh generated. Nodes: {0}, Elements: {1}".format(mesh.Nodes, mesh.Elements)
 ```
 
 ```
-Response: Mesh generated. Nodes: 1381, Elements: 352
+Response: Mesh generated. Nodes: 1424, Elements: 667
 ```
 
-## 7. Get Model Info
+## 8. Get Model Info
 
 **Tool:** `get_model_info`
 
 ```json
 {
-  "geometry": { "body_count": 3 },
-  "mesh": { "node_count": 1381, "element_count": 352 },
+  "geometry": { "body_count": 1 },
+  "mesh": { "node_count": 1424, "element_count": 667 },
   "analyses_count": 1,
   "project": { "product_version": "2025 R2", "name": "Project" },
   "model": { "name": "Model" }
 }
 ```
 
-## 8. Apply Boundary Conditions
+## 9. Create Named Selections for Boundary Conditions
 
 **Tool:** `run_python_script`
+
+> Always use Named Selections to scope loads and supports to specific geometry.
+
+```python
+# Fixed end: face at x=0 (left face of beam)
+ns_group = Model.AddNamedSelection()
+ns_group.ScopingMethod = GeometryDefineByType.Worksheet
+worksheet = ns_group.GenerationCriteria
+criterion = Ansys.ACT.Automation.Mechanical.NamedSelectionCriterion()
+criterion.Active = True
+criterion.Action = SelectionActionType.Add
+criterion.EntityType = SelectionType.GeoFace
+criterion.Criterion = SelectionCriterionType.LocationX
+criterion.Operator = SelectionOperatorType.Equal
+criterion.Value = Quantity("0 [mm]")
+worksheet.Add(criterion)
+ns_group.Generate()
+ns_group.Name = "FixedEnd"
+
+# Force end: face at x=200 (right face of beam)
+ns_force = Model.AddNamedSelection()
+ns_force.ScopingMethod = GeometryDefineByType.Worksheet
+worksheet2 = ns_force.GenerationCriteria
+criterion2 = Ansys.ACT.Automation.Mechanical.NamedSelectionCriterion()
+criterion2.Active = True
+criterion2.Action = SelectionActionType.Add
+criterion2.EntityType = SelectionType.GeoFace
+criterion2.Criterion = SelectionCriterionType.LocationX
+criterion2.Operator = SelectionOperatorType.Equal
+criterion2.Value = Quantity("200 [mm]")
+worksheet2.Add(criterion2)
+ns_force.Generate()
+ns_force.Name = "ForceEnd"
+
+"Named Selections created: FixedEnd, ForceEnd"
+```
+
+```
+Response: Named Selections created: FixedEnd, ForceEnd
+```
+
+## 10. Apply Boundary Conditions
+
+**Tool:** `run_python_script`
+
+> **Force components:** Use `force.YComponent.Output.DiscreteValues = [Quantity("-1000 [N]")]`
+> because `YComponent` is a read-only property — you must set its values via the output table.
 
 ```python
 analysis = Model.Analyses[0]
 
-# Add force
-force = analysis.AddForce()
-force.DefineBy = LoadDefineBy.Components
-
-# Add fixed support
+# Fixed support on FixedEnd
 fixed = analysis.AddFixedSupport()
+ns_fixed = [ns for ns in Model.NamedSelections.Children if ns.Name == "FixedEnd"][0]
+fixed.Location = ns_fixed
 
-"BCs added: {0}, {1}".format(force.Name, fixed.Name)
+# Force on ForceEnd (-Y direction, 1000 N)
+force = analysis.AddForce()
+ns_force = [ns for ns in Model.NamedSelections.Children if ns.Name == "ForceEnd"][0]
+force.Location = ns_force
+force.DefineBy = LoadDefineBy.Components
+force.YComponent.Output.DiscreteValues = [Quantity("-1000 [N]")]
+
+"BCs applied: {0} on FixedEnd, {1} on ForceEnd (Y = -1000 N)".format(fixed.Name, force.Name)
 ```
 
-> **Note:** For proper results, scope loads and supports to Named Selections.
-> Use `run_python_script` with worksheet-based Named Selections or directly
-> assign geometry via `ns.Location`.
+```
+Response: BCs applied: Fixed Support on FixedEnd, Force on ForceEnd (Y = -1000 N)
+```
 
-## 9. Add Result Objects
+## 11. Add Result Objects
 
 **Tool:** `run_python_script`
 
 ```python
 solution = Model.Analyses[0].Solution
 
-# Add result objects
 total_deform = solution.AddTotalDeformation()
 equiv_stress = solution.AddEquivalentStress()
 
@@ -144,48 +224,59 @@ equiv_stress = solution.AddEquivalentStress()
 Response: Results added: Total Deformation, Equivalent Stress
 ```
 
-## 10. Solve
+## 12. Solve and Evaluate Results
 
 **Tool:** `run_python_script`
 
 ```python
 analysis = Model.Analyses[0]
-analysis.Solve()
-"Solve initiated"
-```
+analysis.Solve(True)
 
-## 11. Evaluate Results
-
-**Tool:** `run_python_script`
-
-```python
-solution = Model.Analyses[0].Solution
+solution = analysis.Solution
 solution.EvaluateAllResults()
 
-# Children[0] = SolutionInformation, [1] = TotalDeformation, [2] = EquivalentStress
-total_deform = solution.Children[1]
-equiv_stress = solution.Children[2]
+td = None
+es = None
+for i in range(solution.Children.Count):
+    c = solution.Children[i]
+    if c.Name == "Total Deformation":
+        td = c
+    elif c.Name == "Equivalent Stress":
+        es = c
 
-"Deformation Max: {0}, Stress Max: {1}".format(
-    total_deform.Maximum, equiv_stress.Maximum
+"Solved! Deformation Max: {0}, Stress Max: {1}".format(
+    str(td.Maximum) if td else "N/A",
+    str(es.Maximum) if es else "N/A"
 )
 ```
 
-## 12. Screenshot
+```
+Response: Solved! Deformation Max: 0.00402 [m], Stress Max: 599447794.58 [Pa]
+```
+
+## 13. Activate Result in GUI
+
+**Tool:** `run_python_script`
+
+> Activating a result object displays its contour plot in the Mechanical GUI.
+
+```python
+solution = Model.Analyses[0].Solution
+for i in range(solution.Children.Count):
+    c = solution.Children[i]
+    if c.Name == "Total Deformation":
+        c.Activate()
+        break
+"Total Deformation contour plot displayed in GUI"
+```
+
+## 14. Screenshot
 
 **Tool:** `screenshot`
 
-Returns a PNG image of the Mechanical viewport.
+Returns a PNG image of the Mechanical viewport showing the result contour plot.
 
-## 13. Get Project Directory
-
-**Tool:** `get_project_directory`
-
-```
-Response: Project directory: C:\Users\...\Project_Mech_Files\
-```
-
-## 14. Clear and Disconnect
+## 15. Clear and Disconnect
 
 **Tool:** `clear_mechanical`
 
@@ -203,11 +294,17 @@ Response: Successfully disconnected from Mechanical
 
 ## Important Notes
 
-1. **Use `.format()` instead of f-strings** — Mechanical 2025 R2 uses IronPython 2.7
+1. **GUI Mode:** Always use `batch=false` in `launch_mechanical` to see results
+   interactively. The default is `batch=true` (headless/batch mode).
+2. **Use `.format()` instead of f-strings** — Mechanical 2025 R2 uses IronPython 2.7
    which does not support f-string syntax.
-2. **Use `run_python_script`** for Mechanical API scripting (ExtAPI, Model, etc.).
+3. **Script return values:** The last expression in a `run_python_script` call is
+   returned as the result. Do NOT assign to `result =`; instead end with a bare
+   string expression like `"message: {0}".format(value)`.
+4. **Use `run_python_script`** for Mechanical API scripting (ExtAPI, Model, etc.).
    Use `run_python_code` only for external Python calculations (NumPy, Pandas, etc.).
-3. **Units:** `Quantity("value unit")` syntax works for many contexts. Some unit strings
-   may require the Mechanical-specific unit format.
-4. **Scoping:** Always prefer Named Selections for boundary conditions and results
-   to ensure geometry is properly targeted.
+5. **Units:** Use `Quantity("5 [mm]")` with square brackets for Mechanical unit strings.
+6. **Read-only properties:** Force/moment component properties (e.g. `YComponent`) are
+   read-only. Set values via: `force.YComponent.Output.DiscreteValues = [Quantity("-1000 [N]")]`
+7. **Scoping:** Always use Named Selections (worksheet-based) for boundary conditions
+   and results to ensure geometry is properly targeted.

--- a/examples/static_structural_workflow.md
+++ b/examples/static_structural_workflow.md
@@ -1,0 +1,213 @@
+# Static Structural Analysis Workflow
+
+This example demonstrates a complete Mechanical FEA workflow using the
+pymechanical-mcp tools. All steps were validated live against
+ANSYS Mechanical 2025 R2.
+
+## 1. Check Mechanical Installation
+
+**Tool:** `check_mechanical_installed`
+
+```
+Response: Mechanical is installed on this system.
+```
+
+## 2. Launch Mechanical
+
+**Tool:** `launch_mechanical`
+
+```
+Response:
+  Successfully launched Mechanical
+  Version: 252
+  Project Directory: C:\Users\...\Project_Mech_Files\
+```
+
+## 3. Check Connection Status
+
+**Tool:** `check_mechanical_status`
+
+```json
+{
+  "connection": {
+    "version": "252",
+    "is_alive": true,
+    "busy": false
+  },
+  "product_info": {
+    "raw": "Ansys Mechanical [Ansys Mechanical Enterprise]\nProduct Version:252"
+  },
+  "model": {
+    "model_name": "Model",
+    "product_version": "2025 R2"
+  }
+}
+```
+
+## 4. Create Analysis
+
+**Tool:** `run_python_script`
+
+```python
+analysis = Model.AddStaticStructuralAnalysis()
+"Static Structural analysis added: {0}".format(analysis.Name)
+```
+
+```
+Response: Static Structural analysis added: Static Structural
+```
+
+## 5. Import Geometry
+
+**Tool:** `run_python_script`
+
+```python
+geometry_import = Model.GeometryImportGroup.AddGeometryImport()
+geometry_file = r"C:\path\to\your\model.step"
+geometry_import_format = Ansys.Mechanical.DataModel.Enums.GeometryImportPreference.Format.Automatic
+geometry_import_prefs = Ansys.ACT.Mechanical.Utilities.GeometryImportPreferences()
+geometry_import_prefs.ProcessNamedSelections = True
+geometry_import.Import(geometry_file, geometry_import_format, geometry_import_prefs)
+"Geometry imported: {0} bodies".format(
+    Model.Geometry.GetChildren(DataModelObjectCategory.Body, True).Count
+)
+```
+
+```
+Response: Geometry imported: 3 bodies
+```
+
+## 6. Generate Mesh
+
+**Tool:** `run_python_script`
+
+```python
+mesh = Model.Mesh
+mesh.GenerateMesh()
+"Mesh generated. Nodes: {0}, Elements: {1}".format(mesh.Nodes, mesh.Elements)
+```
+
+```
+Response: Mesh generated. Nodes: 1381, Elements: 352
+```
+
+## 7. Get Model Info
+
+**Tool:** `get_model_info`
+
+```json
+{
+  "geometry": { "body_count": 3 },
+  "mesh": { "node_count": 1381, "element_count": 352 },
+  "analyses_count": 1,
+  "project": { "product_version": "2025 R2", "name": "Project" },
+  "model": { "name": "Model" }
+}
+```
+
+## 8. Apply Boundary Conditions
+
+**Tool:** `run_python_script`
+
+```python
+analysis = Model.Analyses[0]
+
+# Add force
+force = analysis.AddForce()
+force.DefineBy = LoadDefineBy.Components
+
+# Add fixed support
+fixed = analysis.AddFixedSupport()
+
+"BCs added: {0}, {1}".format(force.Name, fixed.Name)
+```
+
+> **Note:** For proper results, scope loads and supports to Named Selections.
+> Use `run_python_script` with worksheet-based Named Selections or directly
+> assign geometry via `ns.Location`.
+
+## 9. Add Result Objects
+
+**Tool:** `run_python_script`
+
+```python
+solution = Model.Analyses[0].Solution
+
+# Add result objects
+total_deform = solution.AddTotalDeformation()
+equiv_stress = solution.AddEquivalentStress()
+
+"Results added: {0}, {1}".format(total_deform.Name, equiv_stress.Name)
+```
+
+```
+Response: Results added: Total Deformation, Equivalent Stress
+```
+
+## 10. Solve
+
+**Tool:** `run_python_script`
+
+```python
+analysis = Model.Analyses[0]
+analysis.Solve()
+"Solve initiated"
+```
+
+## 11. Evaluate Results
+
+**Tool:** `run_python_script`
+
+```python
+solution = Model.Analyses[0].Solution
+solution.EvaluateAllResults()
+
+# Children[0] = SolutionInformation, [1] = TotalDeformation, [2] = EquivalentStress
+total_deform = solution.Children[1]
+equiv_stress = solution.Children[2]
+
+"Deformation Max: {0}, Stress Max: {1}".format(
+    total_deform.Maximum, equiv_stress.Maximum
+)
+```
+
+## 12. Screenshot
+
+**Tool:** `screenshot`
+
+Returns a PNG image of the Mechanical viewport.
+
+## 13. Get Project Directory
+
+**Tool:** `get_project_directory`
+
+```
+Response: Project directory: C:\Users\...\Project_Mech_Files\
+```
+
+## 14. Clear and Disconnect
+
+**Tool:** `clear_mechanical`
+
+```
+Response: Mechanical database cleared successfully.
+```
+
+**Tool:** `disconnect_from_mechanical`
+
+```
+Response: Successfully disconnected from Mechanical
+```
+
+---
+
+## Important Notes
+
+1. **Use `.format()` instead of f-strings** — Mechanical 2025 R2 uses IronPython 2.7
+   which does not support f-string syntax.
+2. **Use `run_python_script`** for Mechanical API scripting (ExtAPI, Model, etc.).
+   Use `run_python_code` only for external Python calculations (NumPy, Pandas, etc.).
+3. **Units:** `Quantity("value unit")` syntax works for many contexts. Some unit strings
+   may require the Mechanical-specific unit format.
+4. **Scoping:** Always prefer Named Selections for boundary conditions and results
+   to ensure geometry is properly targeted.

--- a/src/ansys/mechanical/mcp/contexts.py
+++ b/src/ansys/mechanical/mcp/contexts.py
@@ -148,7 +148,7 @@ bodies = geometry.GetChildren(DataModelObjectCategory.Body, True)
 
 # Iterate through bodies
 for body in bodies:
-    print(f"Body: {body.Name}, Material: {body.Material}")
+    print("Body: {0}, Material: {1}".format(body.Name, body.Material))
 '''
 mechanical.run_python_script(script)
 ```
@@ -264,8 +264,8 @@ mesh = Model.Mesh
 mesh.GenerateMesh()
 
 # Get mesh statistics
-print(f"Nodes: {mesh.Nodes.Count if mesh.Nodes else 0}")
-print(f"Elements: {mesh.Elements.Count if mesh.Elements else 0}")
+print("Nodes: {0}".format(mesh.Nodes.Count if mesh.Nodes else 0))
+print("Elements: {0}".format(mesh.Elements.Count if mesh.Elements else 0))
 '''
 mechanical.run_python_script(script)
 ```
@@ -608,7 +608,7 @@ analysis.Solve()
 
 # Check solution status
 solution = analysis.Solution
-print(f"Status: {solution.Status}")
+print("Status: {0}".format(solution.Status))
 '''
 mechanical.run_python_script(script)
 ```
@@ -620,8 +620,8 @@ script = '''
 solution = Model.Analyses[0].Solution
 
 # Get solution information
-print(f"Solver Type: {solution.SolverType}")
-print(f"Status: {solution.Status}")
+print("Solver Type: {0}".format(solution.SolverType))
+print("Status: {0}".format(solution.Status))
 '''
 mechanical.run_python_script(script)
 ```
@@ -678,9 +678,9 @@ try:
     if analysis.Solution.Status == SolutionStatusType.Done:
         print("Solution completed successfully")
     else:
-        print(f"Solution status: {analysis.Solution.Status}")
+        print("Solution status: {0}".format(analysis.Solution.Status))
 except Exception as e:
-    print(f"Solution error: {e}")
+    print("Solution error: {0}".format(e))
 '''
 mechanical.run_python_script(script)
 ```
@@ -769,9 +769,9 @@ stress = solution.AddEquivalentStress()
 stress.EvaluateAllResults()
 
 # Get min and max values
-print(f"Maximum Stress: {stress.Maximum}")
-print(f"Minimum Stress: {stress.Minimum}")
-print(f"Average Stress: {stress.Average}")
+print("Maximum Stress: {0}".format(stress.Maximum))
+print("Minimum Stress: {0}".format(stress.Minimum))
+print("Average Stress: {0}".format(stress.Average))
 '''
 mechanical.run_python_script(script)
 ```
@@ -787,7 +787,7 @@ for i in range(1, 11):  # First 10 modes
     deform = solution.AddTotalDeformation()
     deform.Mode = i
     deform.EvaluateAllResults()
-    print(f"Mode {i} Frequency: {deform.ReportedFrequency}")
+    print("Mode {0} Frequency: {1}".format(i, deform.ReportedFrequency))
 '''
 mechanical.run_python_script(script)
 ```
@@ -880,7 +880,7 @@ named_selections = Model.NamedSelections.GetChildren(
 )
 
 for ns in named_selections:
-    print(f"Named Selection: {ns.Name}")
+    print("Named Selection: {0}".format(ns.Name))
 '''
 mechanical.run_python_script(script)
 ```
@@ -891,7 +891,7 @@ mechanical.run_python_script(script)
 script = '''
 # Get specific Named Selection
 ns = ExtAPI.DataModel.GetObjectsByName("FixedSupport")[0]
-print(f"Found: {ns.Name}")
+print("Found: {0}".format(ns.Name))
 '''
 mechanical.run_python_script(script)
 ```
@@ -1022,7 +1022,7 @@ mechanical.run_python_script(script)
 try:
     result = mechanical.run_python_script(script)
 except grpc.RpcError as error:
-    print(f"Script error: {error.details()}")
+    print("Script error: {0}".format(error.details()))
 ```
 
 ## File Transfers

--- a/src/ansys/mechanical/mcp/helpers.py
+++ b/src/ansys/mechanical/mcp/helpers.py
@@ -2,6 +2,7 @@
 
 import logging
 import os
+import socket
 import sys
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -22,11 +23,11 @@ def _is_linux() -> bool:
 
 def _is_docker() -> bool:
     """Return True when running inside a Docker container."""
-    return os.path.exists("/.dockerenv") or os.path.isfile("/run/.containerenv")
+    return Path("/.dockerenv").exists() or Path("/run/.containerenv").exists()
 
 
 def _probe_grpc_endpoint(host: str, port: int, timeout: float = 3.0) -> dict[str, Any]:
-    """Probe a gRPC endpoint to check if a Mechanical server is reachable.
+    """Test whether a gRPC endpoint is reachable via a TCP connect probe.
 
     Parameters
     ----------
@@ -39,21 +40,12 @@ def _probe_grpc_endpoint(host: str, port: int, timeout: float = 3.0) -> dict[str
 
     Returns
     -------
-    dict
+    dict[str, Any]
         ``{"reachable": bool, "host": str, "port": int, "error": str | None}``
     """
-    import grpc
-
-    target = f"{host}:{port}"
     try:
-        channel = grpc.insecure_channel(target)
-        try:
-            grpc.channel_ready_future(channel).result(timeout=timeout)
+        with socket.create_connection((host, port), timeout=timeout):
             return {"reachable": True, "host": host, "port": port, "error": None}
-        except grpc.FutureTimeoutError:
-            return {"reachable": False, "host": host, "port": port, "error": "timeout"}
-        finally:
-            channel.close()
     except Exception as e:
         return {"reachable": False, "host": host, "port": port, "error": str(e)}
 

--- a/src/ansys/mechanical/mcp/tools.py
+++ b/src/ansys/mechanical/mcp/tools.py
@@ -3,6 +3,7 @@
 import base64
 import json
 import os
+import re
 import tempfile
 from pathlib import Path
 from typing import Any
@@ -178,6 +179,14 @@ def run_python_script(ctx: Context, script: str) -> str:
         )
 
     try:
+        # Warn about f-strings: Mechanical < 2026 R1 uses IronPython 2.7 which doesn't support them
+        if re.search(r'\bf["\']', script):
+            logger.warning(
+                "Detected f-string syntax in script. Mechanical versions before 2026 R1 "
+                "use IronPython 2.7 which does not support f-strings. If execution fails, "
+                "rewrite using .format() instead."
+            )
+
         result = mechanical.run_python_script(script)
         return f"Script executed successfully. Result: {result}"
     except Exception as e:
@@ -259,6 +268,13 @@ def run_multiple_scripts(ctx: Context, scripts: list[str]) -> str:
     results = []
     for i, script in enumerate(scripts, 1):
         try:
+            # Warn about f-strings (IronPython 2.7 doesn't support them)
+            if re.search(r'\bf["\']', script):
+                logger.warning(
+                    "Script %d contains f-string syntax. Mechanical versions before "
+                    "2026 R1 use IronPython 2.7 which does not support f-strings.", i
+                )
+
             result = mechanical.run_python_script(script)
             results.append(f"Script {i}: Success - {result}")
         except Exception as e:
@@ -348,6 +364,7 @@ def launch_mechanical(
             "batch": batch,
             "loglevel": "INFO",
             "cleanup_on_exit": True,
+            "start_timeout": 300,  # 5 minutes for graphical mode launches
         }
 
         if exec_file is not None:
@@ -820,9 +837,11 @@ else:
 # Get Mesh info
 if hasattr(model, 'Mesh') and model.Mesh is not None:
     mesh = model.Mesh
+    nodes = mesh.Nodes
+    elements = mesh.Elements
     model_info['mesh'] = {
-        'node_count': mesh.Nodes.Count if hasattr(mesh, 'Nodes') and mesh.Nodes else 0,
-        'element_count': mesh.Elements.Count if hasattr(mesh, 'Elements') and mesh.Elements else 0,
+        'node_count': nodes.Count if hasattr(nodes, 'Count') else (nodes if isinstance(nodes, int) else 0),
+        'element_count': elements.Count if hasattr(elements, 'Count') else (elements if isinstance(elements, int) else 0),
     }
 else:
     model_info['mesh'] = {'node_count': 0, 'element_count': 0}
@@ -894,8 +913,17 @@ import os
 # Get the Graphics object
 graphics = ExtAPI.Graphics
 
-# Export the current view to image
-graphics.ExportImage(r"{temp_path}", ImageExportFormat.PNG, GraphicsImageExportSettings())
+# Try different export approaches for version compatibility
+try:
+    # Approach 1: Use GraphicsImageExportFormat enum (2025 R2+)
+    settings = Ansys.Mechanical.Graphics.GraphicsImageExportSettings()
+    settings.Resolution = GraphicsResolutionType.EnhancedResolution
+    settings.Width = 1920
+    settings.Height = 1080
+    graphics.ExportImage(r"{temp_path}", GraphicsImageExportFormat.PNG, settings)
+except:
+    # Approach 2: Simpler export (older versions)
+    graphics.ExportImage(r"{temp_path}")
 
 r"{temp_path}"
 """
@@ -923,9 +951,15 @@ r"{temp_path}"
 
         logger.info(f"Screenshot captured successfully: {temp_path}")
 
+        # Clean up temp file
+        try:
+            os.unlink(temp_path)
+        except OSError:
+            pass
+
         # Return both text (file path) and image content
         return [
-            TextContent(type="text", text=f"Screenshot saved to: {temp_path}"),
+            TextContent(type="text", text="Screenshot captured successfully."),
             ImageContent(type="image", data=base64_data, mimeType=mime_type),
         ]
 


### PR DESCRIPTION
Tool fixes and IronPython compatibility for pymechanical-mcp, validated live against Mechanical 2025 R2.

## Changes
- contexts.py: Convert 15 f-string examples to .format() for IronPython 2.7 compatibility
- helpers.py: Self-contained _is_docker() and _probe_grpc_endpoint() (dict return, TCP socket)
- tools.py: f-string detection changed from hard block to warning log, screenshot simplified to 2 approaches, start_timeout=300 for launch, get_model_info mesh count handles int vs .Count, temp file cleanup
- examples: Add validated static structural analysis workflow