### PR TITLE
feat: add toolsets://definition discovery resource

### DIFF
--- a/src/ansys/mechanical/mcp/server.py
+++ b/src/ansys/mechanical/mcp/server.py
@@ -351,6 +351,7 @@ def launcher(argv: list[str] | None = None) -> None:
         from ansys.mechanical.mcp import contexts  # noqa: F401
     from ansys.mechanical.mcp import prompts  # noqa: F401
     from ansys.mechanical.mcp import tools  # noqa: F401
+    from ansys.mechanical.mcp import toolsets  # noqa: F401
 
     # Guarantee the system prompt is delivered during the MCP initialize handshake
     app.instructions = prompts.SYSTEM_PROMPT

--- a/src/ansys/mechanical/mcp/toolsets.py
+++ b/src/ansys/mechanical/mcp/toolsets.py
@@ -1,0 +1,183 @@
+# Copyright (C) 2025 - 2026 ANSYS, Inc. and/or its affiliates.
+# SPDX-License-Identifier: MIT
+
+"""Toolset definitions for PyAnsysMCPService discovery.
+
+Exposes the ``toolsets://definition`` MCP resource that groups every tool
+registered on the PyMechanical MCP server into logical, user-facing
+categories. Each toolset entry follows the schema agreed across the Ansys
+MCP family:
+
+``{"name": str, "description": str, "skill": str, "tools": list[str]}``
+
+The catalogue is a pure discovery aid — it does not affect tool visibility,
+gating, or runtime behavior. Visibility is still controlled by the existing
+``REQUIRES_MECHANICAL_TAG`` / ``aali`` / ``locked_connection`` tags applied
+in :mod:`ansys.mechanical.mcp.tools`.
+"""
+
+from typing import Any
+
+from ansys.mechanical.mcp import app
+
+#: Master catalogue mapping every logical toolset to its metadata + tool list.
+_TOOLSET_CATALOGUE: dict[str, dict[str, Any]] = {
+    "lifecycle": {
+        "description": (
+            "Tools for installing, launching, attaching to, disconnecting "
+            "from, and tearing down Mechanical sessions."
+        ),
+        "skill": (
+            "Call check_mechanical_installed once at startup to confirm the "
+            "Mechanical binary is on disk. Call check_mechanical_status "
+            "before every workflow to see whether this MCP already has a "
+            "live Mechanical connection. Use list_mechanical_instances to "
+            "discover running Mechanical processes, connect_to_mechanical "
+            "to attach to one (or the user-supplied host:port), and "
+            "launch_mechanical to start a new instance. Use "
+            "disconnect_from_mechanical for a graceful detach and "
+            "clear_mechanical to fully release the process."
+        ),
+        "tools": [
+            "check_mechanical_installed",
+            "check_mechanical_status",
+            "list_mechanical_instances",
+            "launch_mechanical",
+            "connect_to_mechanical",
+            "disconnect_from_mechanical",
+            "clear_mechanical",
+        ],
+    },
+    "scripting": {
+        "description": (
+            "Tools for executing Mechanical (IronPython) scripts and "
+            "Python snippets against the live Mechanical session."
+        ),
+        "skill": (
+            "Use run_python_code to execute an inline snippet, "
+            "run_python_script to execute an inline Mechanical script "
+            "string against ExtAPI, run_python_script_from_file to execute "
+            "a .py file uploaded to the Mechanical working directory, and "
+            "run_multiple_scripts to execute several scripts in one round "
+            "trip. All script tools share the same persistent ExtAPI session."
+        ),
+        "tools": [
+            "run_python_code",
+            "run_python_script",
+            "run_python_script_from_file",
+            "run_multiple_scripts",
+        ],
+    },
+    "project-management": {
+        "description": ("Tools for saving, opening, and locating Mechanical project files."),
+        "skill": (
+            "Use save_project to persist the current project (optionally "
+            "save-as a new path), open_project to load a .mechdb file, and "
+            "get_project_directory to retrieve the working directory used "
+            "by the active session."
+        ),
+        "tools": [
+            "save_project",
+            "open_project",
+            "get_project_directory",
+        ],
+    },
+    "file-management": {
+        "description": (
+            "Tools for transferring files to/from the Mechanical working "
+            "directory and listing its contents."
+        ),
+        "skill": (
+            "Use upload_file to send a local file (geometry, script, deck) "
+            "to the Mechanical working directory, download_file to retrieve "
+            "a generated file (results, logs, exports), and list_files to "
+            "enumerate the working directory."
+        ),
+        "tools": [
+            "upload_file",
+            "download_file",
+            "list_files",
+        ],
+    },
+    "simulation": {
+        "description": "Tools for running the Mechanical solver.",
+        "skill": (
+            "Use solve_analysis to invoke the Mechanical solver on the "
+            "configured analysis system. Confirm boundary conditions, "
+            "mesh, and material assignments are in place first by calling "
+            "get_model_info."
+        ),
+        "tools": [
+            "solve_analysis",
+        ],
+    },
+    "inspection": {
+        "description": (
+            "Tools for inspecting the active Mechanical model and capturing " "screenshots."
+        ),
+        "skill": (
+            "Use get_model_info to retrieve a structured summary of the "
+            "active model (geometry, mesh, materials, analyses, BCs, "
+            "results). Use screenshot to capture the current 3D view as a "
+            "PNG for the user."
+        ),
+        "tools": [
+            "get_model_info",
+            "screenshot",
+        ],
+    },
+    "results": {
+        "description": ("Tools for extracting and exporting Mechanical solver results."),
+        "skill": (
+            "Use export_results after a successful solve_analysis call to "
+            "write result objects to disk. Use create_custom_plot to render "
+            "user-defined post-processing plots (contour, vector, or "
+            "user-supplied expression) on the solved mesh."
+        ),
+        "tools": [
+            "export_results",
+            "create_custom_plot",
+        ],
+    },
+    "guidelines": {
+        "description": (
+            "Reference tool for retrieving PyMechanical / Ansys Mechanical "
+            "scripting guidelines (workflow, geometry, materials, meshing, "
+            "analysis setup, boundary conditions, solution, "
+            "postprocessing, named selections, general rules)."
+        ),
+        "skill": (
+            "Call get_guidelines_for once per topic before generating "
+            "PyMechanical / ExtAPI code. It returns the authoritative "
+            "scripting patterns and best practices for the requested "
+            "workflow step."
+        ),
+        "tools": [
+            "get_guidelines_for",
+        ],
+    },
+}
+
+
+def _build_toolsets() -> list[dict[str, Any]]:
+    """Return the toolset catalogue as the list[dict] payload expected by clients."""
+    return [
+        {
+            "name": name,
+            "description": entry["description"],
+            "skill": entry["skill"],
+            "tools": list(entry["tools"]),
+        }
+        for name, entry in _TOOLSET_CATALOGUE.items()
+    ]
+
+
+@app.resource(
+    "toolsets://definition",
+    name="toolsets_definition",
+    description="Toolset definitions for PyAnsysMCPService discovery.",
+    mime_type="application/json",
+)
+def get_toolsets() -> list[dict[str, Any]]:
+    """Return toolset definitions for PyAnsysMCPService discovery."""
+    return _build_toolsets()

--- a/tests/test_toolsets.py
+++ b/tests/test_toolsets.py
@@ -1,0 +1,105 @@
+"""Tests for the ``toolsets://definition`` MCP resource."""
+
+import asyncio
+
+import pytest
+
+from ansys.mechanical.mcp import contexts  # noqa: F401
+from ansys.mechanical.mcp import tools  # noqa: F401
+from ansys.mechanical.mcp import toolsets as toolsets_module  # noqa: F401
+from ansys.mechanical.mcp.server import app
+from ansys.mechanical.mcp.toolsets import _TOOLSET_CATALOGUE, _build_toolsets
+
+REQUIRED_KEYS = {"name", "description", "skill", "tools"}
+
+
+def _list_tool_names() -> set[str]:
+    async def _list():
+        return await app._local_provider._list_tools()
+
+    return {t.name for t in asyncio.run(_list())}
+
+
+class TestToolsetsResource:
+    def test_build_returns_list(self):
+        result = _build_toolsets()
+        assert isinstance(result, list)
+        assert len(result) > 0
+
+    def test_items_have_required_keys(self):
+        for entry in _build_toolsets():
+            assert REQUIRED_KEYS <= entry.keys(), (
+                f"toolset {entry.get('name')} missing keys: " f"{REQUIRED_KEYS - entry.keys()}"
+            )
+
+    def test_string_fields_are_non_empty(self):
+        for entry in _build_toolsets():
+            for key in ("name", "description", "skill"):
+                assert (
+                    isinstance(entry[key], str) and entry[key].strip()
+                ), f"toolset {entry['name']!r} field {key!r} is empty"
+
+    def test_tools_field_is_list_of_strings(self):
+        for entry in _build_toolsets():
+            assert isinstance(entry["tools"], list)
+            assert all(isinstance(t, str) and t for t in entry["tools"])
+
+    def test_toolset_names_unique(self):
+        names = [e["name"] for e in _build_toolsets()]
+        assert len(names) == len(set(names))
+
+    def test_each_listed_tool_is_a_real_registered_tool(self):
+        registered = _list_tool_names()
+        missing: list[tuple[str, str]] = []
+        for entry in _build_toolsets():
+            for tool in entry["tools"]:
+                if tool not in registered:
+                    missing.append((entry["name"], tool))
+        assert (
+            not missing
+        ), "Toolset catalogue references unregistered tools:\n  - " + "\n  - ".join(
+            f"{ts}: {t}" for ts, t in missing
+        )
+
+    def test_every_registered_tool_appears_in_some_toolset(self):
+        registered = _list_tool_names()
+        listed = {t for e in _build_toolsets() for t in e["tools"]}
+        orphans = registered - listed
+        assert not orphans, (
+            "The following registered tools are not listed in any toolset "
+            "in toolsets.py:\n  - "
+            + "\n  - ".join(sorted(orphans))
+            + "\n\nAdd each to the appropriate toolset in "
+            "ansys/mechanical/mcp/toolsets.py::_TOOLSET_CATALOGUE."
+        )
+
+    def test_no_tool_listed_in_multiple_toolsets(self):
+        seen: dict[str, str] = {}
+        duplicates: list[tuple[str, str, str]] = []
+        for entry in _build_toolsets():
+            for tool in entry["tools"]:
+                if tool in seen:
+                    duplicates.append((tool, seen[tool], entry["name"]))
+                else:
+                    seen[tool] = entry["name"]
+        assert not duplicates, "Tools appearing in multiple toolsets:\n  - " + "\n  - ".join(
+            f"{t} in {a!r} and {b!r}" for t, a, b in duplicates
+        )
+
+    def test_resource_is_registered(self):
+        async def _list():
+            return await app._list_resources()
+
+        resources = asyncio.run(_list())
+        uris = {str(r.uri) for r in resources}
+        assert (
+            "toolsets://definition" in uris
+        ), f"toolsets://definition not registered. Found: {sorted(uris)}"
+
+    def test_catalogue_is_module_constant(self):
+        assert isinstance(_TOOLSET_CATALOGUE, dict)
+        assert _TOOLSET_CATALOGUE
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

Adds a new `toolsets://definition` MCP resource that returns a `list[dict]` catalogue grouping every registered PyMechanical MCP tool into 8 logical, user-facing toolsets (lifecycle, scripting, project-management, file-management, simulation, inspection, results, guidelines).

The schema matches the convention agreed across the PyAnsys MCP family and is consumed by `PyAnsysMCPService` for tool discovery and conductor routing:

```json
{"name": str, "description": str, "skill": str, "tools": list[str]}
```

## Why

- The Service-layer conductor needs a stable, machine-readable grouping of tools per MCP server to route LLM tool calls efficiently.
- A flat tool list is hard for the conductor (and humans) to reason about — toolsets make capability discovery O(1).

## What's NOT changed

- **No tool visibility / gating changes.** Existing tag-based gating (`requires_mechanical`, `locked_connection`, etc.) is preserved unchanged.
- **No runtime behavior changes.** This is a pure discovery aid.

## Tests

- 10 new unit tests in `tests/test_toolsets.py` verifying: required keys, non-empty values, every listed tool resolves to a real registered tool, no orphans, no duplicates, and the resource is exposed on the FastMCP app.
- All 10 pass locally; existing test suite unaffected.

Resolves #8
