### PR TITLE
test: improve unit coverage for helpers/startup paths

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,11 +1,11 @@
 coverage:
-  range: 60..100
+  range: 80..100
   round: down
   precision: 2
   status:
     project:
       default:
-        target: 60%
+        target: 80%
     patch: off
 
 codecov:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,11 +97,14 @@ lint.select = [
   "F",   # pyflakes
   "I",   # isort
   "N",   # pep8-naming
+    "PTH", # flake8-use-pathlib
+    "TD",  # flake8-todos
 ]
 lint.ignore = [
   "D100", # Missing docstring in public module
   "D104", # Missing docstring in public package
   "D401", # First line of docstring should be in imperative mood
+    "TD002", # Missing author in TODO comments
 ]
 lint.per-file-ignores."!src/**.py" = [ "D" ]
 lint.per-file-ignores."__init__.py" = [ "F401" ]

--- a/src/ansys/mechanical/mcp/tools.py
+++ b/src/ansys/mechanical/mcp/tools.py
@@ -973,7 +973,7 @@ r"{temp_path}"
             return [TextContent(type="text", text=f"Screenshot file not created: {temp_path}")]
 
         # Read image data
-        with open(image_path, "rb") as f:
+        with image_path.open("rb") as f:
             image_data = f.read()
 
         # Encode to base64
@@ -986,7 +986,7 @@ r"{temp_path}"
 
         # Clean up temp file
         try:
-            os.unlink(temp_path)
+            Path(temp_path).unlink()
         except OSError:
             pass
 
@@ -1859,7 +1859,7 @@ def _get_mechanical_solve_log(
                 }
             )
 
-    with open(solve_log, "r", encoding="utf-8", errors="replace") as f:
+    with solve_log.open("r", encoding="utf-8", errors="replace") as f:
         all_lines = f.readlines()
 
     filtered = all_lines

--- a/tests/test_helpers_additional.py
+++ b/tests/test_helpers_additional.py
@@ -1,0 +1,152 @@
+# Copyright (C) 2025 - 2026 ANSYS, Inc. and/or its affiliates.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Additional unit tests for helper and startup modules."""
+
+import json
+import runpy
+import sys
+from types import ModuleType, SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+import psutil
+
+from ansys.mechanical.mcp import helpers
+
+
+class _Proc:
+    def __init__(self, name, status, pid, cmdline, cwd="C:/work", children_count=0, cwd_raises=False):
+        self._name = name
+        self._status = status
+        self.pid = pid
+        self._cmdline = cmdline
+        self._cwd = cwd
+        self._children_count = children_count
+        self._cwd_raises = cwd_raises
+
+    def cmdline(self):
+        return self._cmdline
+
+    def status(self):
+        return self._status
+
+    def name(self):
+        return self._name
+
+    def children(self, recursive=True):
+        return [object()] * self._children_count
+
+    def cwd(self):
+        if self._cwd_raises:
+            raise psutil.AccessDenied(pid=self.pid)
+        return self._cwd
+
+
+def test_probe_grpc_endpoint_unreachable(monkeypatch):
+    def _raise(*args, **kwargs):
+        raise OSError("unreachable")
+
+    monkeypatch.setattr(helpers.socket, "create_connection", _raise)
+
+    result = helpers._probe_grpc_endpoint("127.0.0.1", 60000)
+
+    assert result["reachable"] is False
+    assert "unreachable" in result["error"]
+
+
+def test_list_instances_variants(monkeypatch):
+    import psutil
+
+    running = _Proc(
+        name="AnsysWBU.exe",
+        status=psutil.STATUS_RUNNING,
+        pid=101,
+        cmdline=["AnsysWBU.exe", "--port", "10000", "-grpc"],
+        children_count=3,
+    )
+    sleeping = _Proc(
+        name="mechanical",
+        status=psutil.STATUS_SLEEPING,
+        pid=102,
+        cmdline=["mechanical", "--foo"],
+        cwd_raises=True,
+    )
+    other = _Proc(
+        name="python",
+        status=psutil.STATUS_RUNNING,
+        pid=103,
+        cmdline=["python", "script.py"],
+    )
+
+    monkeypatch.setattr(psutil, "process_iter", lambda: [running, sleeping, other])
+
+    table_all = helpers.list_instances(instances=False, cmd=True, location=True)
+    assert "AnsysWBU.exe" in table_all
+    assert "10000" in table_all
+    assert "N/A" in table_all
+
+    table_instances_only = helpers.list_instances(instances=True)
+    assert "AnsysWBU.exe" in table_instances_only
+    assert "mechanical" not in table_instances_only
+
+
+def test_get_info_success():
+    mechanical = MagicMock()
+    mechanical.version = "252"
+    mechanical.project_directory = "C:/project"
+    mechanical.is_alive = True
+    mechanical.name = "Mech"
+    mechanical.busy = False
+    mechanical.exited = False
+    mechanical.get_product_info.return_value = {"product": "Mechanical"}
+    mechanical.run_python_script.return_value = json.dumps(
+        {"product_version": "252", "model_name": "Model"}
+    )
+
+    info = helpers.get_info(mechanical)
+
+    assert info["connection"]["version"] == "252"
+    assert info["product_info"]["raw"]["product"] == "Mechanical"
+    assert info["model"]["model_name"] == "Model"
+
+
+class _BrokenMechanical:
+    @property
+    def version(self):
+        raise RuntimeError("version unavailable")
+
+    def get_product_info(self):
+        raise RuntimeError("product info unavailable")
+
+    def run_python_script(self, script):
+        raise RuntimeError("script failed")
+
+
+def test_get_info_error_paths():
+    info = helpers.get_info(_BrokenMechanical())
+
+    assert "error" in info["connection"]
+    assert "error" in info["product_info"]
+    assert "error" in info["model"]
+
+
+def test_startup_code_error_paths(monkeypatch):
+    from ansys.mechanical.mcp.mechanical_helper import startup_code
+
+    monkeypatch.setattr(startup_code, "MATPLOTLIB_AVAILABLE", False)
+    assert startup_code.save_matplotlib_plot() == "Error: matplotlib is not available"
+
+    monkeypatch.setattr(startup_code, "PYVISTA_AVAILABLE", False)
+    assert startup_code.save_plot(MagicMock()) == "Error: PyVista is not available"
+
+
+def test_module_entrypoint_invokes_launcher(monkeypatch):
+    fake_server = ModuleType("ansys.mechanical.mcp.server")
+    launcher = MagicMock()
+    fake_server.launcher = launcher
+
+    monkeypatch.setitem(sys.modules, "ansys.mechanical.mcp.server", fake_server)
+    runpy.run_module("ansys.mechanical.mcp.__main__", run_name="__main__")
+
+    launcher.assert_called_once()

--- a/tests/test_helpers_additional.py
+++ b/tests/test_helpers_additional.py
@@ -15,7 +15,9 @@ from ansys.mechanical.mcp import helpers
 
 
 class _Proc:
-    def __init__(self, name, status, pid, cmdline, cwd="C:/work", children_count=0, cwd_raises=False):
+    def __init__(
+        self, name, status, pid, cmdline, cwd="C:/work", children_count=0, cwd_raises=False
+    ):
         self._name = name
         self._status = status
         self.pid = pid

--- a/tests/test_helpers_additional.py
+++ b/tests/test_helpers_additional.py
@@ -132,6 +132,20 @@ def test_get_info_error_paths():
     assert "error" in info["model"]
 
 
+def test_sanitize_output_replacements():
+    from ansys.mechanical.mcp import tools
+
+    text = "\u2713 ok \u2717 bad \u2022 bullet \u00a0space \u2588block"
+
+    result = tools._sanitize_output(text)
+
+    assert "[OK]" in result
+    assert "[X]" in result
+    assert "*" in result
+    assert "space" in result
+    assert "#" in result
+
+
 def test_startup_code_error_paths(monkeypatch):
     from ansys.mechanical.mcp.mechanical_helper import startup_code
 
@@ -140,6 +154,54 @@ def test_startup_code_error_paths(monkeypatch):
 
     monkeypatch.setattr(startup_code, "PYVISTA_AVAILABLE", False)
     assert startup_code.save_plot(MagicMock()) == "Error: PyVista is not available"
+
+
+def test_startup_code_save_matplotlib_plot_success(monkeypatch):
+    from ansys.mechanical.mcp.mechanical_helper import startup_code
+
+    buffer = MagicMock()
+    buffer.read.return_value = b"png-bytes"
+    fake_plot = MagicMock()
+    fake_plot.savefig.return_value = None
+    fake_plt = MagicMock()
+    fake_plt.savefig.side_effect = fake_plot.savefig
+    fake_plt.close.return_value = None
+
+    monkeypatch.setattr(startup_code, "MATPLOTLIB_AVAILABLE", True)
+    monkeypatch.setattr(startup_code, "plt", fake_plt)
+    monkeypatch.setattr(startup_code, "BytesIO", lambda: buffer)
+
+    result = startup_code.save_matplotlib_plot(dpi=200)
+
+    assert result.startswith("data:image/png;base64,")
+    fake_plt.savefig.assert_called_once_with(buffer, format="png", dpi=200, bbox_inches="tight")
+    fake_plt.close.assert_called_once()
+
+
+def test_startup_code_save_plot_success(monkeypatch):
+    from ansys.mechanical.mcp.mechanical_helper import startup_code
+
+    image = MagicMock()
+    image.save.return_value = None
+    buffer = MagicMock()
+    buffer.read.return_value = b"plot-bytes"
+    fake_image_module = MagicMock()
+    fake_image_module.fromarray.return_value = image
+    fake_plotter = MagicMock()
+    fake_plotter.screenshot.return_value = [1, 2, 3]
+    fake_plotter.close.return_value = None
+
+    monkeypatch.setattr(startup_code, "PYVISTA_AVAILABLE", True)
+    monkeypatch.setattr(startup_code, "Image", fake_image_module)
+    monkeypatch.setattr(startup_code, "BytesIO", lambda: buffer)
+    monkeypatch.setattr(startup_code.base64, "b64encode", lambda data: b"encoded")
+
+    result = startup_code.save_plot(fake_plotter)
+
+    assert result == "data:image/png;base64,encoded"
+    fake_plotter.screenshot.assert_called_once_with(return_img=True, transparent_background=False)
+    image.save.assert_called_once_with(buffer, format="PNG")
+    fake_plotter.close.assert_called_once()
 
 
 def test_module_entrypoint_invokes_launcher(monkeypatch):

--- a/tests/test_helpers_additional.py
+++ b/tests/test_helpers_additional.py
@@ -6,10 +6,9 @@
 import json
 import runpy
 import sys
-from types import ModuleType, SimpleNamespace
+from types import ModuleType
 from unittest.mock import MagicMock
 
-import pytest
 import psutil
 
 from ansys.mechanical.mcp import helpers

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -23,7 +23,7 @@ To skip integration tests, run: pytest -m "not integration"
 """
 
 import os
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -190,17 +190,18 @@ class TestLaunchMechanicalIntegration:
     @pytest.fixture
     def clean_context(self):
         """Create a clean context with no Mechanical connection."""
-        from unittest.mock import MagicMock
-
         from ansys.mechanical.mcp.server import PyMechanicalAppContext
 
         context = MagicMock()
+        context.enable_components = AsyncMock(return_value=None)
+        context.disable_components = AsyncMock(return_value=None)
         context.request_context = MagicMock()
         context.request_context.lifespan_context = PyMechanicalAppContext(mechanical=None)
 
         return context
 
-    def test_launch_mechanical_basic_workflow(self, clean_context):
+    @pytest.mark.asyncio
+    async def test_launch_mechanical_basic_workflow(self, clean_context):
         """Test launching Mechanical with default parameters and executing scripts.
 
         This test combines multiple scenarios:
@@ -218,7 +219,7 @@ class TestLaunchMechanicalIntegration:
 
         try:
             # Launch Mechanical
-            result = launch_mechanical(clean_context)
+            result = await launch_mechanical(clean_context)
 
             # Verify successful launch
             assert isinstance(result, str)
@@ -245,15 +246,16 @@ class TestLaunchMechanicalIntegration:
             assert "version" in status_data["connection"]
 
             # Test launching when already connected
-            result2 = launch_mechanical(clean_context)
+            result2 = await launch_mechanical(clean_context)
             assert "Already connected to a Mechanical instance" in result2
             assert "disconnect first" in result2
 
         finally:
             # Clean up
-            disconnect_from_mechanical(clean_context)
+            await disconnect_from_mechanical(clean_context)
 
-    def test_launch_mechanical_custom_parameters(self, clean_context):
+    @pytest.mark.asyncio
+    async def test_launch_mechanical_custom_parameters(self, clean_context):
         """Test launching Mechanical with custom parameters.
 
         This test combines:
@@ -267,7 +269,7 @@ class TestLaunchMechanicalIntegration:
         )
 
         try:
-            result = launch_mechanical(clean_context, port=10050)
+            result = await launch_mechanical(clean_context, port=10050)
 
             # Verify successful launch
             assert isinstance(result, str)
@@ -280,7 +282,7 @@ class TestLaunchMechanicalIntegration:
 
         finally:
             # Disconnect Mechanical
-            disconnect_from_mechanical(clean_context)
+            await disconnect_from_mechanical(clean_context)
 
 
 @pytest.mark.integration

--- a/tests/test_log_tools.py
+++ b/tests/test_log_tools.py
@@ -1,0 +1,100 @@
+# Copyright (C) 2025 - 2026 ANSYS, Inc. and/or its affiliates.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for Mechanical log retrieval utilities."""
+
+import json
+
+from ansys.mechanical.mcp import tools
+
+
+def test_get_mechanical_logs_no_connection(mock_context_no_mechanical):
+    result = tools.get_mechanical_logs(mock_context_no_mechanical)
+    assert "No Mechanical connection available" in result
+
+
+def test_get_mechanical_logs_invalid_params(mock_context):
+    assert "tail_lines must be greater than 0" in tools.get_mechanical_logs(
+        mock_context, tail_lines=0
+    )
+    assert "max_chars must be greater than 0" in tools.get_mechanical_logs(
+        mock_context, max_chars=0
+    )
+
+
+def test_get_mechanical_logs_unknown_source(mock_context):
+    result = tools.get_mechanical_logs(mock_context, source="unknown")
+    data = json.loads(result)
+    assert "Unknown source" in data["error"]
+
+
+def test_get_mechanical_messages_json_and_filter(mock_mechanical):
+    mock_mechanical.run_python_script.return_value = json.dumps(
+        [
+            {"severity": "Info", "source": "A", "summary": "startup"},
+            {"severity": "Error", "source": "Solver", "summary": "failed"},
+        ]
+    )
+
+    result = tools._get_mechanical_messages(
+        mock_mechanical, tail_lines=10, contains="error", max_chars=40000
+    )
+    data = json.loads(result)
+
+    assert data["source"] == "messages"
+    assert data["total_messages"] == 1
+    assert "failed" in data["logs"]
+
+
+def test_get_mechanical_messages_raw_fallback(mock_mechanical):
+    mock_mechanical.run_python_script.return_value = "line1\nline2\nline3"
+
+    result = tools._get_mechanical_messages(
+        mock_mechanical, tail_lines=2, contains=None, max_chars=40000
+    )
+    data = json.loads(result)
+
+    assert data["returned_lines"] == 2
+    assert "line2" in data["logs"]
+    assert "line3" in data["logs"]
+
+
+def test_get_mechanical_solve_log_not_found(tmp_path, mock_mechanical):
+    mock_mechanical.project_directory = str(tmp_path)
+
+    result = tools._get_mechanical_solve_log(
+        mock_mechanical, tail_lines=5, contains=None, max_chars=10000
+    )
+    data = json.loads(result)
+
+    assert data["source"] == "solve_log"
+    assert "solve.out not found" in data["error"]
+
+
+def test_get_mechanical_solve_log_rglob_and_truncation(tmp_path, mock_mechanical):
+    nested = tmp_path / "nested"
+    nested.mkdir(parents=True, exist_ok=True)
+    solve_log = nested / "solve.out"
+    solve_log.write_text("INFO start\nERROR bad\nINFO end\n", encoding="utf-8")
+
+    mock_mechanical.project_directory = str(tmp_path)
+
+    result = tools._get_mechanical_solve_log(
+        mock_mechanical,
+        tail_lines=10,
+        contains="info",
+        max_chars=8,
+    )
+    data = json.loads(result)
+
+    assert data["source"] == "solve_log"
+    assert data["matched_lines"] == 2
+    assert data["truncated"] is True
+
+
+def test_get_mechanical_logs_source_routes(mock_context, monkeypatch):
+    monkeypatch.setattr(tools, "_get_mechanical_messages", lambda *args, **kwargs: "MSG")
+    monkeypatch.setattr(tools, "_get_mechanical_solve_log", lambda *args, **kwargs: "SOLVE")
+
+    assert tools.get_mechanical_logs(mock_context, source="messages") == "MSG"
+    assert tools.get_mechanical_logs(mock_context, source="solve_log") == "SOLVE"


### PR DESCRIPTION
## Summary
- Raised test coverage from ~83% to 90%.
- Fixed 2 failing integration tests.
- Closed standards gaps to align with pymapdl-mcp baseline.

## What was added
- New log-tool test module: tests/test_log_tools.py (messages and solve-log paths).
- Async-safe integration fixture update for launch/disconnect workflows.
- Ruff parity update: enabled PTH and TD rules.
- Pathlib refactor in runtime code to satisfy PTH checks.
- Codecov policy tightened from 60% to 80% target.

## Validation
- pre-commit --all-files: pass (ruff, mypy, bandit, formatting).
- Full suite: 242 passed.
- Coverage: 90% overall.