### PR TITLE
ci: use PYANSYS_CI_BOT_TOKEN for doc-deploy-dev

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -242,7 +242,7 @@ jobs:
         uses: ansys/actions/doc-deploy-dev@d946b24b9a765f4169bcc94afdb27bd1a0533741 #v10.3.2
         with:
           cname: ${{ env.DOCUMENTATION_CNAME }}
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.PYANSYS_CI_BOT_TOKEN }}
           bot-user: ${{ secrets.PYANSYS_CI_BOT_USERNAME }}
           bot-email: ${{ secrets.PYANSYS_CI_BOT_EMAIL }}
 

--- a/doc/changelog.d/28.maintenance.md
+++ b/doc/changelog.d/28.maintenance.md
@@ -1,0 +1,1 @@
+Use PYANSYS_CI_BOT_TOKEN for doc-deploy-dev


### PR DESCRIPTION
## Summary

Use `PYANSYS_CI_BOT_TOKEN` instead of `GITHUB_TOKEN` for the `doc-deploy-dev` job.

## Root cause

The `ansys/actions/doc-deploy-dev` action cleans up closed PR preview folders on
gh-pages. During cleanup it calls `gh pr view` and `gh pr comment` via the
provided token. `GITHUB_TOKEN` on a push-triggered job does not have the required
PR/issue write scope for those operations, causing the step to exit with code 1.

This has been failing on every main merge since PR #16 introduced the gh-pages
`pull/` preview directory that triggers the cleanup path.

## Impact

Without this fix, docs are never deployed to
https://mechanical-mcp.docs.pyansys.com/ on any merge to main.