### PR TITLE
feat: prefer GUI Mechanical launches by default

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -177,8 +177,8 @@ jobs:
             -e ANSYSLMD_LICENSE_FILE="1055@${LICENSE_SERVER}" \
             -p ${PYMECHANICAL_PORT}:${PYMECHANICAL_PORT} \
             --entrypoint=tini \
-            ghcr.io/ansys/mechanical:25.2.0 \
-            -- xvfb-run /install/ansys_inc/v252/aisol/.workbench \
+            ghcr.io/ansys/mechanical:26.1.0 \
+            -- xvfb-run /install/ansys_inc/v261/aisol/.workbench \
             -dsapplet -b -grpc ${PYMECHANICAL_PORT} --grpc-host 0.0.0.0 --transport-mode insecure
           timeout 240 bash -c 'until (echo > /dev/tcp/127.0.0.1/10000) >/dev/null 2>&1; do sleep 2; done'
         env:

--- a/README.md
+++ b/README.md
@@ -15,6 +15,9 @@ server that enables AI assistants to interact with Ansys Mechanical through
 [PyMechanical](https://mechanical.docs.pyansys.com/). Use natural language to set up,
 solve, and postprocess structural, thermal, and multiphysics simulations.
 
+PyMechanical-MCP uses PyMechanical's remote-session mode over gRPC. It does not
+use PyMechanical embedding mode.
+
 ## Overview
 
 Key features:
@@ -75,6 +78,11 @@ MCP-compatible clients, see
 [IDE and client configuration](https://mechanical-mcp.docs.pyansys.com/version/stable/getting_started/ide_configuration.html)
 in the documentation.
 
+When you call `launch_mechanical` without specifying `batch`, PyMechanical-MCP
+prefers a visible GUI session. If the MCP client supports elicitation, the
+server can ask the user to choose between GUI and batch mode at launch time.
+Use `batch=true` to force a background launch.
+
 ## Configuration
 
 Use STDIO for local MCP clients. Use HTTP transport for remote access in trusted
@@ -91,6 +99,15 @@ Run with HTTP transport:
 ```bash
 ansys-mechanical-mcp --transport http --http-host 127.0.0.1 --http-port 8080
 ```
+
+To connect to a Mechanical instance that was started manually, launch
+Mechanical with gRPC enabled first. Example PowerShell command:
+
+```powershell
+& "C:\Program Files\ANSYS Inc\v252\aisol\bin\winx64\AnsysWBU.exe" -DSApplet -AppModeMech -grpc 50053
+```
+
+Then use `connect_to_mechanical` with `ip=127.0.0.1` and `port=50053`.
 
 Common configuration options:
 

--- a/README.md
+++ b/README.md
@@ -15,9 +15,6 @@ server that enables AI assistants to interact with Ansys Mechanical through
 [PyMechanical](https://mechanical.docs.pyansys.com/). Use natural language to set up,
 solve, and postprocess structural, thermal, and multiphysics simulations.
 
-PyMechanical-MCP uses PyMechanical's remote-session mode over gRPC. It does not
-use PyMechanical embedding mode.
-
 ## Overview
 
 Key features:
@@ -78,10 +75,8 @@ MCP-compatible clients, see
 [IDE and client configuration](https://mechanical-mcp.docs.pyansys.com/version/stable/getting_started/ide_configuration.html)
 in the documentation.
 
-When you call `launch_mechanical` without specifying `batch`, PyMechanical-MCP
-prefers a visible GUI session. If the MCP client supports elicitation, the
-server can ask the user to choose between GUI and batch mode at launch time.
-Use `batch=true` to force a background launch.
+For launch and connect workflows, including GUI and batch mode behavior, see
+[Quick start](https://mechanical-mcp.docs.pyansys.com/version/stable/getting_started/quick_start.html).
 
 ## Configuration
 
@@ -99,15 +94,6 @@ Run with HTTP transport:
 ```bash
 ansys-mechanical-mcp --transport http --http-host 127.0.0.1 --http-port 8080
 ```
-
-To connect to a Mechanical instance that was started manually, launch
-Mechanical with gRPC enabled first. Example PowerShell command:
-
-```powershell
-& "C:\Program Files\ANSYS Inc\v252\aisol\bin\winx64\AnsysWBU.exe" -DSApplet -AppModeMech -grpc 50053
-```
-
-Then use `connect_to_mechanical` with `ip=127.0.0.1` and `port=50053`.
 
 Common configuration options:
 

--- a/doc/changelog.d/40.added.md
+++ b/doc/changelog.d/40.added.md
@@ -1,0 +1,1 @@
+Prefer GUI Mechanical launches by default

--- a/doc/source/getting_started/installation.rst
+++ b/doc/source/getting_started/installation.rst
@@ -47,6 +47,29 @@ Use Streamable HTTP transport for remote or server-style deployments:
 
    ansys-mechanical-mcp --transport http --http-host 127.0.0.1 --http-port 8080
 
+PyMechanical mode and launch behavior
+-------------------------------------
+
+PyMechanical-MCP uses PyMechanical remote-session mode over gRPC. It does not
+use PyMechanical embedding mode.
+
+When you call ``launch_mechanical`` without specifying ``batch``,
+PyMechanical-MCP prefers a visible GUI session. If the MCP client supports
+elicitation, the server can ask the user to choose between GUI and batch mode
+at launch time. Use ``batch=true`` to force a background launch.
+
+Launch Mechanical manually with gRPC
+------------------------------------
+
+If you want to attach PyMechanical-MCP to a Mechanical session that you start
+yourself, launch Mechanical with gRPC enabled first. Example PowerShell command:
+
+.. code-block:: powershell
+
+   & "C:\Program Files\ANSYS Inc\v252\aisol\bin\winx64\AnsysWBU.exe" -DSApplet -AppModeMech -grpc 50053
+
+Then call ``connect_to_mechanical`` with ``ip=127.0.0.1`` and ``port=50053``.
+
 Connect on startup (optional)
 -----------------------------
 

--- a/doc/source/getting_started/installation.rst
+++ b/doc/source/getting_started/installation.rst
@@ -47,29 +47,6 @@ Use Streamable HTTP transport for remote or server-style deployments:
 
    ansys-mechanical-mcp --transport http --http-host 127.0.0.1 --http-port 8080
 
-PyMechanical mode and launch behavior
--------------------------------------
-
-PyMechanical-MCP uses PyMechanical remote-session mode over gRPC. It does not
-use PyMechanical embedding mode.
-
-When you call ``launch_mechanical`` without specifying ``batch``,
-PyMechanical-MCP prefers a visible GUI session. If the MCP client supports
-elicitation, the server can ask the user to choose between GUI and batch mode
-at launch time. Use ``batch=true`` to force a background launch.
-
-Launch Mechanical manually with gRPC
-------------------------------------
-
-If you want to attach PyMechanical-MCP to a Mechanical session that you start
-yourself, launch Mechanical with gRPC enabled first. Example PowerShell command:
-
-.. code-block:: powershell
-
-   & "C:\Program Files\ANSYS Inc\v252\aisol\bin\winx64\AnsysWBU.exe" -DSApplet -AppModeMech -grpc 50053
-
-Then call ``connect_to_mechanical`` with ``ip=127.0.0.1`` and ``port=50053``.
-
 Connect on startup (optional)
 -----------------------------
 

--- a/doc/source/getting_started/quick_start.rst
+++ b/doc/source/getting_started/quick_start.rst
@@ -36,10 +36,9 @@ There are three common ways to begin once the server is running.
 
 Ask your assistant to call ``launch_mechanical``.
 
-PyMechanical-MCP uses PyMechanical remote-session mode over gRPC. By default,
-``launch_mechanical`` prefers a visible GUI session. If the MCP client supports
-elicitation, it can ask whether to launch in GUI or batch mode. Use
-``batch=true`` to force a background launch.
+By default, ``launch_mechanical`` prefers a visible GUI session. If the MCP
+client supports elicitation, it can ask whether to launch in GUI or batch mode.
+Use ``batch=true`` to force a background launch.
 
 **Option 2: Connect to an existing Mechanical session.**
 

--- a/doc/source/getting_started/quick_start.rst
+++ b/doc/source/getting_started/quick_start.rst
@@ -36,9 +36,23 @@ There are three common ways to begin once the server is running.
 
 Ask your assistant to call ``launch_mechanical``.
 
+PyMechanical-MCP uses PyMechanical remote-session mode over gRPC. By default,
+``launch_mechanical`` prefers a visible GUI session. If the MCP client supports
+elicitation, it can ask whether to launch in GUI or batch mode. Use
+``batch=true`` to force a background launch.
+
 **Option 2: Connect to an existing Mechanical session.**
 
 Ask your assistant to call ``connect_to_mechanical`` with the host and port.
+
+The existing Mechanical session must already be running with gRPC enabled. For
+example, on Windows PowerShell:
+
+.. code-block:: powershell
+
+   & "C:\Program Files\ANSYS Inc\v252\aisol\bin\winx64\AnsysWBU.exe" -DSApplet -AppModeMech -grpc 50053
+
+Then connect with ``ip=127.0.0.1`` and ``port=50053``.
 
 **Option 3: Connect on startup.**
 

--- a/doc/source/getting_started/quick_start.rst
+++ b/doc/source/getting_started/quick_start.rst
@@ -49,7 +49,7 @@ example, on Windows PowerShell:
 
 .. code-block:: powershell
 
-   & "C:\Program Files\ANSYS Inc\v252\aisol\bin\winx64\AnsysWBU.exe" -DSApplet -AppModeMech -grpc 50053
+   & "C:\Program Files\ANSYS Inc\v261\aisol\bin\winx64\AnsysWBU.exe" -DSApplet -AppModeMech -grpc 50053
 
 Then connect with ``ip=127.0.0.1`` and ``port=50053``.
 

--- a/doc/source/user_guide/overview.rst
+++ b/doc/source/user_guide/overview.rst
@@ -25,8 +25,16 @@ PyMechanical-MCP runs a FastMCP server and exposes a set of tools that map
 to Mechanical operations. A client (Visual Studio Code, Claude Code, Claude Desktop,
 or a custom MCP client) invokes tools over STDIO or Streamable HTTP transport.
 
+PyMechanical-MCP uses PyMechanical remote-session mode over gRPC. It does not
+use PyMechanical embedding mode.
+
 The server maintains a persistent app context that stores connection
 state and execution session data across tool calls.
+
+When you call ``launch_mechanical`` without specifying ``batch``,
+PyMechanical-MCP prefers a visible GUI session. If the MCP client supports
+elicitation, it can ask the user to choose between GUI and batch mode before
+launching. Use ``batch=true`` to force a background launch.
 
 Connection-aware tool visibility
 --------------------------------

--- a/doc/source/user_guide/tools_and_capabilities.rst
+++ b/doc/source/user_guide/tools_and_capabilities.rst
@@ -81,12 +81,6 @@ Available after connection
   the ``launch_mechanical``, ``connect_to_mechanical``, and
   ``disconnect_from_mechanical`` tools by design.
 
-.. note::
-  PyMechanical-MCP uses PyMechanical remote-session mode over gRPC, not
-  embedding mode. When ``launch_mechanical`` is called without a ``batch``
-  value, the server prefers a visible GUI session and can ask the client to
-  choose GUI or batch mode when elicitation is supported.
-
 Guideline topics
 ----------------
 

--- a/doc/source/user_guide/tools_and_capabilities.rst
+++ b/doc/source/user_guide/tools_and_capabilities.rst
@@ -30,7 +30,7 @@ Always available (before connection)
    * - ``list_mechanical_instances``
      - List running Mechanical processes.
    * - ``launch_mechanical``
-     - Start a new Mechanical session.
+     - Start a new Mechanical session. GUI is preferred by default, and batch mode remains available.
    * - ``connect_to_mechanical``
      - Attach to an existing Mechanical instance.
    * - ``get_guidelines_for``
@@ -80,6 +80,12 @@ Available after connection
   When you run with ``--connect-on-startup``, PyMechanical-MCP disables
   the ``launch_mechanical``, ``connect_to_mechanical``, and
   ``disconnect_from_mechanical`` tools by design.
+
+.. note::
+  PyMechanical-MCP uses PyMechanical remote-session mode over gRPC, not
+  embedding mode. When ``launch_mechanical`` is called without a ``batch``
+  value, the server prefers a visible GUI session and can ask the client to
+  choose GUI or batch mode when elicitation is supported.
 
 Guideline topics
 ----------------

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -42,7 +42,7 @@ services:
       - ANSYSLMD_LICENSE_FILE=${ANSYSLMD_LICENSE_FILE:-1055@license-server}
     ports:
       - '10000:10000'
-    image: 'ghcr.io/ansys/mechanical:25.2.0'
+    image: 'ghcr.io/ansys/mechanical:26.1.0'
     user: "0:0"
     networks:
       - mcp

--- a/examples/static_structural_workflow.md
+++ b/examples/static_structural_workflow.md
@@ -2,7 +2,7 @@
 
 This example demonstrates a complete Mechanical FEA workflow using the
 pymechanical-mcp tools. All steps were validated live against
-ANSYS Mechanical 2025 R2 on April 21, 2026.
+ANSYS Mechanical 2026 R1 on April 21, 2026.
 
 > **GUI Mode:** Launch Mechanical with `batch=false` so the GUI is visible
 > and you can see geometry, mesh, and result contour plots interactively.
@@ -44,7 +44,7 @@ Response: Mechanical is installed on this system.
 ```
 Response:
   Successfully launched Mechanical
-  Version: 252
+  Version: 261
   Project Directory: C:\Users\...\Project_Mech_Files\
 ```
 
@@ -55,16 +55,16 @@ Response:
 ```json
 {
   "connection": {
-    "version": "252",
+    "version": "261",
     "is_alive": true,
     "busy": false
   },
   "product_info": {
-    "raw": "Ansys Mechanical [Ansys Mechanical Enterprise]\nProduct Version:252"
+    "raw": "Ansys Mechanical [Ansys Mechanical Enterprise]\nProduct Version:261"
   },
   "model": {
     "model_name": "Model",
-    "product_version": "2025 R2"
+    "product_version": "2026 R1"
   }
 }
 ```
@@ -144,7 +144,7 @@ Response: Mesh generated. Nodes: 1424, Elements: 667
   "geometry": { "body_count": 1 },
   "mesh": { "node_count": 1424, "element_count": 667 },
   "analyses_count": 1,
-  "project": { "product_version": "2025 R2", "name": "Project" },
+  "project": { "product_version": "2026 R1", "name": "Project" },
   "model": { "name": "Model" }
 }
 ```
@@ -309,10 +309,10 @@ Response: Successfully disconnected from Mechanical
 
 ## Important Notes
 
-1. **GUI Mode:** Always use `batch=false` in `launch_mechanical` to see results
-   interactively. The default is `batch=true` (headless/batch mode).
-2. **Use `.format()` instead of f-strings**: Mechanical 2025 R2 uses IronPython 2.7
-   which does not support f-string syntax.
+1. **GUI Mode:** `launch_mechanical` prefers a visible GUI session by default.
+  Use `batch=true` only when you explicitly want headless/batch mode.
+2. **Use `.format()` instead of f-strings**: Mechanical versions before 2026 R1
+  use IronPython 2.7, which does not support f-string syntax.
 3. **Script return values:** The last expression in a `run_python_script` call is
    returned as the result. Do NOT assign to `result =`; instead end with a bare
    string expression like `"message: {0}".format(value)`.

--- a/src/ansys/mechanical/mcp/contexts.py
+++ b/src/ansys/mechanical/mcp/contexts.py
@@ -1144,7 +1144,7 @@ omega = Quantity("10 [rad/s]")
 mechanical.run_python_script(script)
 ```
 
-## IronPython compatibility (Mechanical 2025 R2 and earlier)
+## IronPython compatibility for older Mechanical versions
 
 Mechanical versions before 2026 R1 use **IronPython 2.7**. Do NOT use:
 - f-strings (`f"value: {x}"`): use `.format()` instead
@@ -1206,7 +1206,8 @@ mechanical.download_project(target_dir="./project_backup")
 - **No boundary conditions** causing rigid body motion
 - **Forgetting to evaluate results** after adding result objects
 - **Path issues**: Use raw strings (r"path") or double backslashes
-- **Using f-strings**: Mechanical 2025 R2 uses IronPython 2.7 (no f-strings)
+- **Using f-strings**: Mechanical versions before 2026 R1 use IronPython 2.7
+    (no f-strings)
 - **Wrong Quantity format**: Use `Quantity("5 [mm]")` with square brackets
 - **Setting component values directly**: Use `.Output.DiscreteValues = [...]`
 

--- a/src/ansys/mechanical/mcp/tools.py
+++ b/src/ansys/mechanical/mcp/tools.py
@@ -17,6 +17,7 @@
 """List of tools in PyMechanical-MCP."""
 
 import base64
+import inspect
 import json
 import os
 from pathlib import Path
@@ -48,6 +49,48 @@ logger = get_logger(__name__)
 # These tools are disabled at startup (before Mechanical is connected) and enabled
 # once a connection is established via connect_to_mechanical or launch_mechanical.
 REQUIRES_MECHANICAL_TAG = "requires_mechanical"
+
+
+async def _resolve_launch_batch_mode(ctx: Context, batch: bool | None) -> bool:
+    """Resolve the Mechanical launch mode.
+
+    When the caller omits ``batch``, try to elicit a GUI-vs-batch choice from
+    the MCP client. If elicitation is unavailable or the user declines, default
+    to GUI mode for interactive workflows.
+    """
+    if batch is not None:
+        return bool(batch)
+
+    elicit = getattr(ctx, "elicit", None)
+    if elicit is None or not inspect.iscoroutinefunction(elicit):
+        return False
+
+    try:
+        result = await elicit(
+            (
+                "Choose how to launch Mechanical. GUI mode opens a visible "
+                "Mechanical window and is recommended for interactive MCP "
+                "workflows. Batch mode runs in the background without a visible UI."
+            ),
+            {
+                "gui": {"title": "GUI (recommended)"},
+                "batch": {"title": "Batch / background"},
+            },
+            response_title="Launch mode",
+            response_description="Select how the Mechanical gRPC session should be started.",
+        )
+    except Exception as exc:
+        logger.info(
+            "Launch-mode elicitation unavailable; defaulting to GUI mode: %s",
+            exc,
+        )
+        return False
+
+    if result.action == "accept":
+        selection = str(result.data)
+        return selection == "batch"
+
+    return False
 
 
 # Access type-safe lifespan context in tools
@@ -252,7 +295,7 @@ async def launch_mechanical(
     ctx: Context,
     exec_file: str | None = None,
     port: int | None = None,
-    batch: bool = True,
+    batch: bool | None = None,
     version: str | None = None,
     transport_mode: str | None = None,
 ) -> str:
@@ -273,8 +316,10 @@ async def launch_mechanical(
         to find the executable automatically.
     port : int, default: None
         gRPC port for Mechanical to listen on. If ``None``, ``10000`` is used.
-    batch : bool, default: True
-        Whether to launch Mechanical in batch mode.
+    batch : bool | None, default: None
+        Whether to launch Mechanical in batch mode. When omitted, PyMechanical-MCP
+        tries to ask the client to choose between GUI and batch mode and falls back
+        to GUI mode if elicitation is unavailable.
     version : str, default: None
         Mechanical version to run (such as "252" for 2025 R2). If ``None``, the
         latest installed version is used.
@@ -320,9 +365,11 @@ async def launch_mechanical(
             certs_dir=effective_certs,
         )
 
+        resolved_batch = await _resolve_launch_batch_mode(ctx, batch)
+
         # Launch new Mechanical instance
         kwargs: dict[str, Any] = {
-            "batch": batch,
+            "batch": resolved_batch,
             "loglevel": "INFO",
             "cleanup_on_exit": True,
             "start_timeout": 300,  # 5 minutes for graphical mode launches

--- a/src/ansys/mechanical/mcp/tools.py
+++ b/src/ansys/mechanical/mcp/tools.py
@@ -923,7 +923,7 @@ graphics = ExtAPI.Graphics
 
 # Try different export approaches for version compatibility
 try:
-    # Approach 1: Use GraphicsImageExportFormat enum (2025 R2+)
+    # Approach 1: Use GraphicsImageExportFormat enum when available.
     settings = Ansys.Mechanical.Graphics.GraphicsImageExportSettings()
     settings.Resolution = GraphicsResolutionType.EnhancedResolution
     settings.Width = 1920

--- a/src/ansys/mechanical/mcp/tools.py
+++ b/src/ansys/mechanical/mcp/tools.py
@@ -321,7 +321,7 @@ async def launch_mechanical(
         tries to ask the client to choose between GUI and batch mode and falls back
         to GUI mode if elicitation is unavailable.
     version : str, default: None
-        Mechanical version to run (such as "252" for 2025 R2). If ``None``, the
+        Mechanical version to run (such as "261" for 2026 R1). If ``None``, the
         latest installed version is used.
     transport_mode : str, default: None
         gRPC transport mode for the launched instance. Options are ``auto``,

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -17,7 +17,7 @@
 """Tests for MCP tools functionality."""
 
 import json
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from mcp.types import TextContent
 import pytest
@@ -557,6 +557,9 @@ class TestLaunchMechanical:
                 return_value=(None, None),
             ),
         ):
+            mock_context_no_mechanical.elicit = AsyncMock(
+                side_effect=RuntimeError("elicitation unavailable")
+            )
             result = await launch_mechanical(mock_context_no_mechanical)
 
             # Verify successful launch
@@ -566,7 +569,7 @@ class TestLaunchMechanical:
 
             # Verify launch_mechanical was called with correct parameters
             mock_launch.assert_called_once_with(
-                batch=True,
+                batch=False,
                 loglevel="INFO",
                 cleanup_on_exit=True,
                 start_timeout=300,
@@ -585,6 +588,10 @@ class TestLaunchMechanical:
         mock_mechanical.version = "2024 R2"
         mock_mechanical.project_directory = "/tmp/ansys_mechanical_1234"
 
+        mock_context_no_mechanical.elicit = AsyncMock(
+            side_effect=RuntimeError("elicitation unavailable")
+        )
+
         with (
             patch(
                 "ansys.mechanical.mcp.tools.pymechanical.launch_mechanical",
@@ -602,7 +609,7 @@ class TestLaunchMechanical:
 
             # Verify launch_mechanical was called with correct port
             mock_launch.assert_called_once_with(
-                batch=True,
+                batch=False,
                 loglevel="INFO",
                 cleanup_on_exit=True,
                 start_timeout=300,
@@ -615,6 +622,10 @@ class TestLaunchMechanical:
         mock_mechanical = MagicMock()
         mock_mechanical.version = "2025 R2"
         mock_mechanical.project_directory = "/tmp/ansys_mechanical_1234"
+
+        mock_context_no_mechanical.elicit = AsyncMock(
+            side_effect=RuntimeError("elicitation unavailable")
+        )
 
         with (
             patch(
@@ -634,11 +645,42 @@ class TestLaunchMechanical:
 
             # Verify launch_mechanical was called with version
             mock_launch.assert_called_once_with(
-                batch=True,
+                batch=False,
                 loglevel="INFO",
                 cleanup_on_exit=True,
                 start_timeout=300,
                 version="252",
+            )
+
+    @pytest.mark.asyncio
+    async def test_launch_uses_prompted_batch_choice(self, mock_context_no_mechanical):
+        """Test launching Mechanical in batch mode when the client selects it."""
+        mock_mechanical = MagicMock()
+        mock_mechanical.version = "2024 R2"
+        mock_mechanical.project_directory = "/tmp/ansys_mechanical_1234"
+
+        mock_context_no_mechanical.elicit = AsyncMock(
+            return_value=MagicMock(action="accept", data="batch")
+        )
+
+        with (
+            patch(
+                "ansys.mechanical.mcp.tools.pymechanical.launch_mechanical",
+                return_value=mock_mechanical,
+            ) as mock_launch,
+            patch(
+                "ansys.mechanical.mcp.tools.resolve_transport_mode",
+                return_value=(None, None),
+            ),
+        ):
+            result = await launch_mechanical(mock_context_no_mechanical)
+
+            assert "Successfully launched Mechanical" in result
+            mock_launch.assert_called_once_with(
+                batch=True,
+                loglevel="INFO",
+                cleanup_on_exit=True,
+                start_timeout=300,
             )
 
     @pytest.mark.asyncio
@@ -776,6 +818,10 @@ class TestLaunchMechanical:
         mock_mechanical.version = "2024 R2"
         mock_mechanical.project_directory = "/tmp/ansys_mechanical_1234"
 
+        mock_context_no_mechanical.elicit = AsyncMock(
+            side_effect=RuntimeError("elicitation unavailable")
+        )
+
         with (
             patch(
                 "ansys.mechanical.mcp.tools.pymechanical.launch_mechanical",
@@ -794,7 +840,7 @@ class TestLaunchMechanical:
 
             # Verify launch_mechanical was called with port
             mock_launch.assert_called_once_with(
-                batch=True,
+                batch=False,
                 loglevel="INFO",
                 cleanup_on_exit=True,
                 start_timeout=300,

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -684,6 +684,100 @@ class TestLaunchMechanical:
             )
 
     @pytest.mark.asyncio
+    async def test_launch_uses_prompted_gui_choice(self, mock_context_no_mechanical):
+        """Test launching Mechanical in GUI mode when the client selects it."""
+        mock_mechanical = MagicMock()
+        mock_mechanical.version = "2024 R2"
+        mock_mechanical.project_directory = "/tmp/ansys_mechanical_1234"
+
+        mock_context_no_mechanical.elicit = AsyncMock(
+            return_value=MagicMock(action="accept", data="gui")
+        )
+
+        with (
+            patch(
+                "ansys.mechanical.mcp.tools.pymechanical.launch_mechanical",
+                return_value=mock_mechanical,
+            ) as mock_launch,
+            patch(
+                "ansys.mechanical.mcp.tools.resolve_transport_mode",
+                return_value=(None, None),
+            ),
+        ):
+            result = await launch_mechanical(mock_context_no_mechanical)
+
+            assert "Successfully launched Mechanical" in result
+            mock_launch.assert_called_once_with(
+                batch=False,
+                loglevel="INFO",
+                cleanup_on_exit=True,
+                start_timeout=300,
+            )
+
+    @pytest.mark.parametrize("action", ["decline", "cancel"])
+    @pytest.mark.asyncio
+    async def test_launch_defaults_to_gui_when_prompt_not_accepted(
+        self, mock_context_no_mechanical, action
+    ):
+        """Test launching Mechanical in GUI mode when the client declines or cancels."""
+        mock_mechanical = MagicMock()
+        mock_mechanical.version = "2024 R2"
+        mock_mechanical.project_directory = "/tmp/ansys_mechanical_1234"
+
+        mock_context_no_mechanical.elicit = AsyncMock(
+            return_value=MagicMock(action=action, data=None)
+        )
+
+        with (
+            patch(
+                "ansys.mechanical.mcp.tools.pymechanical.launch_mechanical",
+                return_value=mock_mechanical,
+            ) as mock_launch,
+            patch(
+                "ansys.mechanical.mcp.tools.resolve_transport_mode",
+                return_value=(None, None),
+            ),
+        ):
+            result = await launch_mechanical(mock_context_no_mechanical)
+
+            assert "Successfully launched Mechanical" in result
+            mock_launch.assert_called_once_with(
+                batch=False,
+                loglevel="INFO",
+                cleanup_on_exit=True,
+                start_timeout=300,
+            )
+
+    @pytest.mark.asyncio
+    async def test_launch_explicit_batch_true_skips_prompt(self, mock_context_no_mechanical):
+        """Test launching Mechanical in batch mode when explicitly requested."""
+        mock_mechanical = MagicMock()
+        mock_mechanical.version = "2024 R2"
+        mock_mechanical.project_directory = "/tmp/ansys_mechanical_1234"
+        mock_context_no_mechanical.elicit = AsyncMock()
+
+        with (
+            patch(
+                "ansys.mechanical.mcp.tools.pymechanical.launch_mechanical",
+                return_value=mock_mechanical,
+            ) as mock_launch,
+            patch(
+                "ansys.mechanical.mcp.tools.resolve_transport_mode",
+                return_value=(None, None),
+            ),
+        ):
+            result = await launch_mechanical(mock_context_no_mechanical, batch=True)
+
+            assert "Successfully launched Mechanical" in result
+            mock_context_no_mechanical.elicit.assert_not_awaited()
+            mock_launch.assert_called_once_with(
+                batch=True,
+                loglevel="INFO",
+                cleanup_on_exit=True,
+                start_timeout=300,
+            )
+
+    @pytest.mark.asyncio
     async def test_launch_all_custom_parameters(self, mock_context_no_mechanical):
         """Test launching Mechanical with all custom parameters."""
         mock_mechanical = MagicMock()


### PR DESCRIPTION
## Summary
- prefer GUI launches when batch is not provided
- opportunistically prompt for GUI or batch mode when the MCP client supports elicitation, with a safe GUI fallback
- document that PyMechanical-MCP uses PyMechanical remote-session gRPC mode rather than embedding mode
- add the manual Mechanical gRPC launch command for users who want to launch Mechanical themselves
- docs: use latest mechanical version references

## Validation
- pytest tests/test_tools.py -k launch tests/test_transport_mode.py -k launch`n- .\\.venv\\Scripts\\python -m sphinx -b dummy doc/source doc/_build/dummy -W --keep-going`n
Closes #39