### PR TITLE
build: consolidate dependabot updates (#50, #51, #52, #53, #54)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,7 +140,7 @@ jobs:
         python-version: ["3.12", "3.13", "3.14"]
     steps:
       - name: "Run unit tests"
-        uses: ansys/actions/tests-pytest@a5b0351dc277d68c2dc1beca2d2674c7dfa4fc55 #v10.3.3
+        uses: ansys/actions/tests-pytest@84b6533ae76f5dde69a1df26c18682160a8121cf #v10.3.5
         with:
           python-version: ${{ matrix.python-version }}
           pytest-markers: '-m "not integration"'
@@ -185,7 +185,7 @@ jobs:
           LICENSE_SERVER: ${{ secrets.LICENSE_SERVER }}
 
       - name: "Run integration tests"
-        uses: ansys/actions/tests-pytest@a5b0351dc277d68c2dc1beca2d2674c7dfa4fc55 #v10.3.3
+        uses: ansys/actions/tests-pytest@84b6533ae76f5dde69a1df26c18682160a8121cf #v10.3.5
         with:
           python-version: ${{ env.MAIN_PYTHON_VERSION }}
           pytest-markers: '-m "integration"'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -274,7 +274,7 @@ jobs:
       contents: write # Required for GitHub release
     steps:
       - name: "Release to GitHub"
-        uses: ansys/actions/release-github@7419880d64bb0bba83f968ca803611df0b76faf0 # v10.3.4
+        uses: ansys/actions/release-github@84b6533ae76f5dde69a1df26c18682160a8121cf # v10.3.5
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           library-name: ${{ env.PACKAGE_NAME }}

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -46,7 +46,7 @@ jobs:
 
     # Label based on modified files
     - name: "Label based on changed files"
-      uses: actions/labeler@f27b608878404679385c85cfa523b85ccb86e213 # v6.1.0
+      uses: actions/labeler@bf12e9b00b37c5c0ca2b87b79b2daf7891dbda13 # v7.0.0
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
         sync-labels: true

--- a/doc/changelog.d/50.dependencies.md
+++ b/doc/changelog.d/50.dependencies.md
@@ -1,0 +1,1 @@
+Bump ansys/actions/tests-pytest from 10.3.3 to 10.3.5

--- a/doc/changelog.d/51.dependencies.md
+++ b/doc/changelog.d/51.dependencies.md
@@ -1,0 +1,1 @@
+Bump ansys-mechanical-core from 0.12.11 to 0.12.12

--- a/doc/changelog.d/52.dependencies.md
+++ b/doc/changelog.d/52.dependencies.md
@@ -1,0 +1,1 @@
+Bump actions/labeler from 6.1.0 to 7.0.0

--- a/doc/changelog.d/53.dependencies.md
+++ b/doc/changelog.d/53.dependencies.md
@@ -1,0 +1,1 @@
+Bump matplotlib from 3.11.0 to 3.11.1

--- a/doc/changelog.d/54.dependencies.md
+++ b/doc/changelog.d/54.dependencies.md
@@ -1,0 +1,1 @@
+Bump ansys/actions/release-github from 10.3.4 to 10.3.5

--- a/doc/changelog.d/57.dependencies.md
+++ b/doc/changelog.d/57.dependencies.md
@@ -1,0 +1,1 @@
+Consolidate dependabot updates (#50, #51, #52, #53, #54)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ dependencies = [
 [project.optional-dependencies]
 tests = [
     "ansys-common-mcp==0.3.3",
-    "ansys-mechanical-core==0.12.11",
+    "ansys-mechanical-core==0.12.12",
     "matplotlib==3.11.0",
     "pytest==9.1.1",
     "pytest-asyncio==1.4.0",
@@ -61,7 +61,7 @@ tests = [
 
 doc = [
     "ansys-common-mcp==0.3.3",
-    "ansys-mechanical-core==0.12.11",
+    "ansys-mechanical-core==0.12.12",
     "ansys-sphinx-theme[autoapi,changelog]==1.9.0",
     "matplotlib==3.11.0",
     "numpydoc==1.10.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ classifiers = [
 dependencies = [
     "ansys-mechanical-core>=0.12.0",
     "ansys-common-mcp>=0.3.0",
-    "matplotlib==3.11.0",
+    "matplotlib==3.11.1",
     "tabulate==0.10.0",
 ]
 
@@ -51,7 +51,7 @@ dependencies = [
 tests = [
     "ansys-common-mcp==0.3.3",
     "ansys-mechanical-core==0.12.12",
-    "matplotlib==3.11.0",
+    "matplotlib==3.11.1",
     "pytest==9.1.1",
     "pytest-asyncio==1.4.0",
     "pytest-cov==7.1.0",
@@ -63,7 +63,7 @@ doc = [
     "ansys-common-mcp==0.3.3",
     "ansys-mechanical-core==0.12.12",
     "ansys-sphinx-theme[autoapi,changelog]==1.9.0",
-    "matplotlib==3.11.0",
+    "matplotlib==3.11.1",
     "numpydoc==1.10.0",
     "sphinx-autodoc-typehints==3.6.1",
     "sphinx-design==0.7.0",


### PR DESCRIPTION
Consolidates the following open Dependabot PRs into one branch to avoid repeated update-branch/CI cycles:

- #50 build(actions): bump ansys/actions/tests-pytest from 10.3.3 to 10.3.5
- #51 build(pip): bump ansys-mechanical-core from 0.12.11 to 0.12.12
- #52 build(actions): bump actions/labeler from 6.1.0 to 7.0.0
- #53 build(pip): bump matplotlib from 3.11.0 to 3.11.1
- #54 build(actions): bump ansys/actions/release-github from 10.3.4 to 10.3.5

All original commits (bump + changelog fragment) were cherry-picked as-is. One conflict in pyproject.toml (test extras, #51 vs #53 both touching adjacent lines) was resolved by keeping both bumps: \ansys-mechanical-core==0.12.12\ and \matplotlib==3.11.1\.

Closes #50, #51, #52, #53, #54