### PR TITLE
ci: group dependabot updates and track pre-commit hooks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,10 @@ updates:
       - "dependencies"
     commit-message:
       prefix: "build(pip)"
+    groups:
+      pip-deps:
+        patterns:
+          - "*"
 
   - package-ecosystem: "github-actions"
     cooldown:
@@ -29,3 +33,25 @@ updates:
       - "dependencies"
     commit-message:
       prefix: "build(actions)"
+    groups:
+      actions:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "pre-commit"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+      exclude:
+        - "ansys/pre-commit-hooks"
+    labels:
+      - "maintenance"
+      - "dependencies"
+    commit-message:
+      prefix: "build(pre-commit)"
+    groups:
+      pre-commit:
+        patterns:
+          - "*"

--- a/doc/changelog.d/61.maintenance.md
+++ b/doc/changelog.d/61.maintenance.md
@@ -1,0 +1,1 @@
+Group dependabot updates and track pre-commit hooks


### PR DESCRIPTION
## Issue

Every scheduled Dependabot run opened one PR per individual dependency bump (e.g. #50–#54), instead of a single combined PR. Each one needed its own branch update + full CI run before merge.

## Root cause

`dependabot.yml` had no `groups` key configured for the `pip` or `github-actions` ecosystems. Without `groups`, Dependabot's default behavior is one PR per update. It also had no `pre-commit` ecosystem entry at all, even though the repo has a `.pre-commit-config.yaml` with hook versions that can go stale unnoticed.

## Fix

- Added `groups: pip-deps: patterns: ["*"]` to the `pip` ecosystem, so all pip bumps in a run are combined into one PR.
- Added `groups: actions: patterns: ["*"]` to the `github-actions` ecosystem, so all action bumps in a run are combined into one PR.
- Added a new `pre-commit` ecosystem block (weekly schedule, 7-day cooldown, excludes `ansys/pre-commit-hooks` consistent with the existing `ansys/actions` exclude pattern) with `groups: pre-commit: patterns: ["*"]`, so pre-commit hook versions are now tracked and grouped too.

No existing schedule, cooldown, label, or commit-message settings were changed — only `groups` was added to the two existing ecosystems, plus the new `pre-commit` block.

## Validation

- `.github/dependabot.yml` parses as valid YAML.
- Confirmed each ecosystem now reports a `groups` entry: `pip -> pip-deps`, `github-actions -> actions`, `pre-commit -> pre-commit`.
