### PR TITLE
ci: bump check-vulnerabilities action to v10.3.6 to fix flaky vulnerability scan

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,7 +95,7 @@ jobs:
       security-events: write # Needed to create security advisories
       issues: write # Needed to create issues for new advisories
     steps:
-      - uses: ansys/actions/check-vulnerabilities@7419880d64bb0bba83f968ca803611df0b76faf0 #v10.3.4
+      - uses: ansys/actions/check-vulnerabilities@9dc4e3161033d2c2485fbf9687d40cfb7a661fb2 #v10.3.6
         with:
           python-version: ${{ env.MAIN_PYTHON_VERSION }}
           python-package-name: ${{ env.PACKAGE_NAME }}

--- a/doc/changelog.d/65.maintenance.md
+++ b/doc/changelog.d/65.maintenance.md
@@ -1,0 +1,1 @@
+Bump ``ansys/actions/check-vulnerabilities`` to v10.3.6 to fix flaky vulnerability scan failures

--- a/doc/changelog.d/65.maintenance.md
+++ b/doc/changelog.d/65.maintenance.md
@@ -1,1 +1,1 @@
-Bump ``ansys/actions/check-vulnerabilities`` to v10.3.6 to fix flaky vulnerability scan failures
+Bump check-vulnerabilities action to v10.3.6 to fix flaky vulnerability scan


### PR DESCRIPTION
## Issue

The `Vulnerabilities` CI job has been intermittently failing across PRs (e.g. #62, #63, #64) with:

```
ImportError: Blocked import of regex from current working directory for security reasons.
```

## Fix

Bump `ansys/actions/check-vulnerabilities` from `v10.3.4` to `v10.3.6` (latest). This is a targeted, minimal version bump — only this one action reference is touched; the repo's Dependabot `actions` group will pick up bumping the rest on its next scheduled run now that grouping is configured (#61).

## Validation

- Confirmed `v10.3.6`'s `check-vulnerabilities/requirements.txt` includes `nltk<=3.9.4`, absent from `v10.3.4`.
- `pyaedt-mcp`, already on `v10.3.6`, has not shown this failure on its current `main`.
