### PR TITLE
revert: chore(release): prepare (static-tools + post-merge fixes) (#70)

### DIFF
--- a/doc/changelog.d/70.maintenance.md
+++ b/doc/changelog.d/70.maintenance.md
@@ -1,1 +1,0 @@
-Prepare v1.1.0 (static-tools + post-merge fixes)

--- a/doc/changelog.d/76.miscellaneous.md
+++ b/doc/changelog.d/76.miscellaneous.md
@@ -1,1 +1,1 @@
-Chore(release): prepare v1.1.0 (static-tools + post-merge fixes) (#70)
+Chore(release): prepare (static-tools + post-merge fixes) (#70)

--- a/doc/changelog.d/76.miscellaneous.md
+++ b/doc/changelog.d/76.miscellaneous.md
@@ -1,1 +1,1 @@
-Undo v1.1.0 release prep (#70)
+Chore(release): prepare v1.1.0 (static-tools + post-merge fixes) (#70)

--- a/doc/changelog.d/76.miscellaneous.md
+++ b/doc/changelog.d/76.miscellaneous.md
@@ -1,0 +1,1 @@
+Undo v1.1.0 release prep (#70)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "flit_core.buildapi"
 
 [project]
 name = "ansys-mechanical-mcp"
-version = "1.1.0"
+version = "0.1.2"
 description = "Model Context Protocol (MCP) server for Ansys Mechanical through PyMechanical"
 readme = "README.md"
 requires-python = ">=3.12,<4"

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -84,30 +84,6 @@ def real_context(mock_mechanical):
     return context
 
 
-@pytest.fixture(scope="class")
-def real_mechanical():
-    """Connect to a real Mechanical instance for integration tests.
-
-    This requires Mechanical to be running on localhost:10000.
-    Skip these tests if Mechanical is not available locally.
-    """
-    try:
-        mechanical, externally_managed = _get_real_mechanical_connection()
-
-        yield mechanical
-
-        # Only terminate when this test launched the process locally.
-        if not externally_managed:
-            mechanical.exit()
-
-    except Exception as e:
-        # Fail hard in CI, skip locally when Mechanical is unavailable.
-        if ON_CI:
-            raise e
-        else:
-            pytest.skip(f"Mechanical not available: {e}")
-
-
 @pytest.mark.integration
 @pytest.mark.slow
 class TestMechanicalIntegration:
@@ -116,6 +92,30 @@ class TestMechanicalIntegration:
     This class combines all basic Mechanical integration tests to share a single
     Mechanical instance, reducing test execution time.
     """
+
+    @pytest.fixture(scope="class")
+    def real_mechanical(self):
+        """
+        Fixture to connect to a real Mechanical instance.
+
+        This requires Mechanical to be running on localhost:10000.
+        Skip these tests if Mechanical is not available.
+        """
+        try:
+            mechanical, externally_managed = _get_real_mechanical_connection()
+
+            yield mechanical
+
+            # Only terminate when this test launched the process locally.
+            if not externally_managed:
+                mechanical.exit()
+
+        except Exception as e:
+            # Fail hard in CI, skip locally when Mechanical is unavailable.
+            if ON_CI:
+                raise e
+            else:
+                pytest.skip(f"Mechanical not available: {e}")
 
     @pytest.fixture()
     def mechanical(self, real_mechanical):
@@ -230,7 +230,7 @@ class TestLaunchMechanicalIntegration:
             # Test launching when already connected
             result2 = await launch_mechanical(clean_context)
             assert "Already connected to a Mechanical instance" in result2
-            assert "disconnect first" in result2.lower()
+            assert "disconnect first" in result2
 
         finally:
             # Clean up
@@ -271,6 +271,28 @@ class TestLaunchMechanicalIntegration:
 @pytest.mark.slow
 class TestPythonPersistentSessionIntegration:
     """Integration tests for connecting to Mechanical in persistent Python session."""
+
+    @pytest.fixture(scope="class")
+    def real_mechanical(self):
+        """
+        Fixture to connect to a real Mechanical instance.
+
+        This requires Mechanical to be running on localhost:10000.
+        Skip these tests if Mechanical is not available.
+        """
+        try:
+            mechanical, externally_managed = _get_real_mechanical_connection()
+
+            yield mechanical
+
+            if not externally_managed:
+                mechanical.exit()
+
+        except Exception as e:
+            if ON_CI:
+                raise e
+            else:
+                pytest.skip(f"Mechanical not available: {e}")
 
     @pytest.fixture
     def persistent_real_context(self, real_mechanical):


### PR DESCRIPTION
## Summary
- Revert merged PR #70 (`chore(release): prepare (static-tools + post-merge fixes)`).
- Undo release-version change that targeted `v1.1.0`.

## What This Reverts
- `pyproject.toml` version bump from `0.1.2` to `1.1.0`.
- Changelog fragment added for the mistaken `v1.1.0` prep.

## Why
- `v1.1.0` was the wrong target for this release cycle.
- We will re-open release preparation with the correct `0.2.x` versioning after this rollback merges.

## Traceability
- Original PR: #70
- Original merge commit on `main`: `1cc49da96e68198a8948dcc58dc4734346b14280`