### PR TITLE
chore: update CHANGELOG for v0.2.0

### DIFF
--- a/doc/changelog.d/60.maintenance.md
+++ b/doc/changelog.d/60.maintenance.md
@@ -1,1 +1,0 @@
-Update CHANGELOG for v0.1.2

--- a/doc/changelog.d/61.maintenance.md
+++ b/doc/changelog.d/61.maintenance.md
@@ -1,1 +1,0 @@
-Group dependabot updates and track pre-commit hooks

--- a/doc/changelog.d/62.dependencies.md
+++ b/doc/changelog.d/62.dependencies.md
@@ -1,1 +1,0 @@
-Bump the pip-deps group with 2 updates

--- a/doc/changelog.d/64.dependencies.md
+++ b/doc/changelog.d/64.dependencies.md
@@ -1,1 +1,0 @@
-Bump the pre-commit group with 3 updates

--- a/doc/changelog.d/65.maintenance.md
+++ b/doc/changelog.d/65.maintenance.md
@@ -1,1 +1,0 @@
-Bump check-vulnerabilities action to v10.3.6 to fix flaky vulnerability scan

--- a/doc/changelog.d/66.dependencies.md
+++ b/doc/changelog.d/66.dependencies.md
@@ -1,1 +1,0 @@
-Bump the actions group across 1 directory with 13 updates

--- a/doc/changelog.d/67.dependencies.md
+++ b/doc/changelog.d/67.dependencies.md
@@ -1,1 +1,0 @@
-Bump https://github.com/crate-ci/typos from v1.48.0 to 5.0.7 in the pre-commit group

--- a/doc/changelog.d/69.added.md
+++ b/doc/changelog.d/69.added.md
@@ -1,1 +1,0 @@
-Add --static-tools flag to expose all tools from startup

--- a/doc/changelog.d/71.maintenance.md
+++ b/doc/changelog.d/71.maintenance.md
@@ -1,1 +1,0 @@
-Update missing or outdated files

--- a/doc/changelog.d/72.dependencies.md
+++ b/doc/changelog.d/72.dependencies.md
@@ -1,1 +1,0 @@
-Bump https://github.com/astral-sh/ruff-pre-commit from v0.16.0 to 0.16.1 in the pre-commit group

--- a/doc/changelog.d/73.dependencies.md
+++ b/doc/changelog.d/73.dependencies.md
@@ -1,1 +1,0 @@
-Bump the pip-deps group with 4 updates

--- a/doc/changelog.d/74.dependencies.md
+++ b/doc/changelog.d/74.dependencies.md
@@ -1,1 +1,0 @@
-Bump the actions group with 2 updates

--- a/doc/changelog.d/76.miscellaneous.md
+++ b/doc/changelog.d/76.miscellaneous.md
@@ -1,1 +1,0 @@
-Chore(release): prepare (static-tools + post-merge fixes) (#70)

--- a/doc/changelog.d/78.maintenance.md
+++ b/doc/changelog.d/78.maintenance.md
@@ -1,1 +1,0 @@
-Prepare v0.2.0 (static-tools + post-merge fixes)

--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -9,6 +9,82 @@ This section contains the release notes for PyMechanical-MCP.
 
 .. towncrier release notes start
 
+`0.2.0 <https://github.com/ansys/pymechanical-mcp/releases/tag/v0.2.0>`_ - August 12, 2026
+==========================================================================================
+
+.. tab-set::
+
+
+  .. tab-item:: Added
+
+    .. list-table::
+        :header-rows: 0
+        :widths: auto
+
+        * - Add --static-tools flag to expose all tools from startup
+          - `#69 <https://github.com/ansys/pymechanical-mcp/pull/69>`_
+
+
+  .. tab-item:: Dependencies
+
+    .. list-table::
+        :header-rows: 0
+        :widths: auto
+
+        * - Bump the pip-deps group with 2 updates
+          - `#62 <https://github.com/ansys/pymechanical-mcp/pull/62>`_
+
+        * - Bump the pre-commit group with 3 updates
+          - `#64 <https://github.com/ansys/pymechanical-mcp/pull/64>`_
+
+        * - Bump the actions group across 1 directory with 13 updates
+          - `#66 <https://github.com/ansys/pymechanical-mcp/pull/66>`_
+
+        * - Bump https://github.com/crate-ci/typos from v1.48.0 to 5.0.7 in the pre-commit group
+          - `#67 <https://github.com/ansys/pymechanical-mcp/pull/67>`_
+
+        * - Bump https://github.com/astral-sh/ruff-pre-commit from v0.16.0 to 0.16.1 in the pre-commit group
+          - `#72 <https://github.com/ansys/pymechanical-mcp/pull/72>`_
+
+        * - Bump the pip-deps group with 4 updates
+          - `#73 <https://github.com/ansys/pymechanical-mcp/pull/73>`_
+
+        * - Bump the actions group with 2 updates
+          - `#74 <https://github.com/ansys/pymechanical-mcp/pull/74>`_
+
+
+  .. tab-item:: Maintenance
+
+    .. list-table::
+        :header-rows: 0
+        :widths: auto
+
+        * - Update CHANGELOG for v0.1.2
+          - `#60 <https://github.com/ansys/pymechanical-mcp/pull/60>`_
+
+        * - Group dependabot updates and track pre-commit hooks
+          - `#61 <https://github.com/ansys/pymechanical-mcp/pull/61>`_
+
+        * - Bump check-vulnerabilities action to v10.3.6 to fix flaky vulnerability scan
+          - `#65 <https://github.com/ansys/pymechanical-mcp/pull/65>`_
+
+        * - Update missing or outdated files
+          - `#71 <https://github.com/ansys/pymechanical-mcp/pull/71>`_
+
+        * - Prepare v0.2.0 (static-tools + post-merge fixes)
+          - `#78 <https://github.com/ansys/pymechanical-mcp/pull/78>`_
+
+
+  .. tab-item:: Miscellaneous
+
+    .. list-table::
+        :header-rows: 0
+        :widths: auto
+
+        * - Chore(release): prepare (static-tools + post-merge fixes) (#70)
+          - `#76 <https://github.com/ansys/pymechanical-mcp/pull/76>`_
+
+
 `0.1.2 <https://github.com/ansys/pymechanical-mcp/releases/tag/v0.1.2>`_ - 2026-07-29
 =====================================================================================
 


### PR DESCRIPTION
## Summary\n- Restore the changelog update that should accompany release 0.2.0.\n- Update doc/source/changelog.rst and remove consumed doc/changelog.d/*.md fragments.\n\n## Context\n- The original autogenerated changelog PR (#79) was closed during cleanup.\n- This PR reinstates the same changelog/docs content so docs stay consistent with the released version.\n