### PR TITLE
fix: improve MCP startup diagnostics and reliability

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,33 +168,11 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: "Pull Mechanical image with retry"
-        shell: bash
-        run: |
-          set -euo pipefail
-          image="ghcr.io/ansys/mechanical:26.1.0"
-          for attempt in 1 2 3 4 5 6 7 8; do
-            if docker pull "${image}"; then
-              exit 0
-            fi
-            if [ "${attempt}" -eq 8 ]; then
-              echo "Unable to pull ${image} after ${attempt} attempts." >&2
-              exit 1
-            fi
-            delay=$((15 * (2 ** (attempt - 1))))
-            if [ "${delay}" -gt 120 ]; then
-              delay=120
-            fi
-            echo "Pull attempt ${attempt} failed; retrying in ${delay} seconds." >&2
-            sleep "${delay}"
-          done
-
       - name: "Launch Mechanical instance"
         shell: bash
         run: |
           set -euo pipefail
           docker run -d \
-            --pull=never \
             --name mechanical-remote \
             -e ANSYSLMD_LICENSE_FILE="1055@${LICENSE_SERVER}" \
             -p ${PYMECHANICAL_PORT}:${PYMECHANICAL_PORT} \

--- a/README.md
+++ b/README.md
@@ -30,12 +30,12 @@ Key features:
 
 ## Tool surface
 
-You can use 21 tools exposed by the server, grouped as follows:
+You can use 23 tools exposed by the server, grouped as follows:
 
 | Group | Tools |
 |-------|-------|
-| Connection and lifecycle | `check_mechanical_status`, `check_mechanical_installed`, `launch_mechanical`, `connect_to_mechanical`, `disconnect_from_mechanical`, `list_mechanical_instances` |
-| File and project management | `list_files`, `upload_file`, `download_file`, `clear_mechanical`, `save_project`, `open_project` |
+| Connection and lifecycle | `check_mechanical_status`, `get_session_diagnostics`, `check_mechanical_installed`, `launch_mechanical`, `connect_to_mechanical`, `disconnect_from_mechanical`, `list_mechanical_instances` |
+| File and project management | `list_files`, `upload_file`, `download_file`, `download_project`, `clear_mechanical`, `save_project`, `open_project` |
 | Mechanical scripting and solve | `run_python_script`, `solve_analysis`, `get_model_info`, `export_results` |
 | Visualization and diagnostics | `screenshot`, `create_custom_plot`, `get_mechanical_logs` |
 | Persistent Python execution | `run_python_code` |

--- a/doc/changelog.d/88.fixed.md
+++ b/doc/changelog.d/88.fixed.md
@@ -1,2 +1,1 @@
-Improve MCP startup reliability by deferring optional plotting imports and add
-safe session diagnostics and bulk project downloads.
+Improve MCP startup diagnostics and reliability

--- a/doc/changelog.d/88.fixed.md
+++ b/doc/changelog.d/88.fixed.md
@@ -1,0 +1,2 @@
+Improve MCP startup reliability by deferring optional plotting imports and add
+safe session diagnostics and bulk project downloads.

--- a/doc/source/getting_started/quick_start.rst
+++ b/doc/source/getting_started/quick_start.rst
@@ -73,6 +73,7 @@ Before connection, use offline-capable tools such as:
 
 - ``check_mechanical_installed``
 - ``check_mechanical_status``
+- ``get_session_diagnostics``
 - ``list_mechanical_instances``
 - ``get_guidelines_for``
 

--- a/doc/source/user_guide/best_practices.rst
+++ b/doc/source/user_guide/best_practices.rst
@@ -11,6 +11,7 @@ Repeated launch/connect cycles increase runtime and can create confusion in
 stateful workflows.
 
 - Call ``check_mechanical_status`` before starting each major step.
+- Call ``get_session_diagnostics`` when diagnosing persistent Python startup or connection issues.
 - Use ``connect_to_mechanical`` if a compatible instance already exists.
 - Use ``disconnect_from_mechanical`` for clean shutdowns.
 
@@ -52,6 +53,7 @@ File transfer hygiene
 - Use ``upload_file`` for all client-side artifacts (geometry and scripts).
 - Keep working directory contents organized (prefix or suffix by workflow).
 - Retrieve only required artifacts with ``download_file``.
+- Use ``download_project`` when a complete project archive is required.
 
 AI workflow guidance
 --------------------

--- a/doc/source/user_guide/tools_and_capabilities.rst
+++ b/doc/source/user_guide/tools_and_capabilities.rst
@@ -33,6 +33,8 @@ Always available (before connection)
      - Verify that Mechanical is installed and discoverable.
    * - ``check_mechanical_status``
      - Inspect current MCP connection state.
+   * - ``get_session_diagnostics``
+     - Return non-sensitive Mechanical and persistent Python session diagnostics.
    * - ``list_mechanical_instances``
      - List running Mechanical processes.
    * - ``launch_mechanical``
@@ -69,6 +71,8 @@ Available after connection
      - Upload local file to Mechanical working directory.
    * - ``download_file``
      - Download file from Mechanical working directory.
+   * - ``download_project``
+     - Download all supported project files, optionally filtered by extension.
    * - ``list_files``
      - List files in working directory.
    * - ``solve_analysis``

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "flit_core.buildapi"
 
 [project]
 name = "ansys-mechanical-mcp"
-version = "0.2.0"
+version = "0.2.1"
 description = "Model Context Protocol (MCP) server for Ansys Mechanical through PyMechanical"
 readme = "README.md"
 requires-python = ">=3.12,<4"

--- a/src/ansys/mechanical/mcp/errors.py
+++ b/src/ansys/mechanical/mcp/errors.py
@@ -1,0 +1,58 @@
+# Copyright (C) 2026 Synopsys, Inc. and ANSYS, Inc. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Structured errors returned by PyMechanical MCP tools."""
+
+from typing import Any
+
+
+class MechanicalMCPError(Exception):
+    """Base error carrying a stable machine-readable error code."""
+
+    error_code = "internal_error"
+
+    def __init__(self, message: str, *, details: dict[str, Any] | None = None) -> None:
+        """Initialize the error with a user-safe message and optional details."""
+        super().__init__(message)
+        self.message = message
+        self.details = details or {}
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-serializable error payload."""
+        return {
+            "success": False,
+            "error_code": self.error_code,
+            "error": self.message,
+            "details": self.details,
+        }
+
+
+class NotConnectedError(MechanicalMCPError):
+    """Raised when an operation requires an active Mechanical connection."""
+
+    error_code = "not_connected"
+
+
+class InvalidArgumentsError(MechanicalMCPError):
+    """Raised when tool arguments are invalid or unusable."""
+
+    error_code = "invalid_arguments"
+
+
+class UpstreamError(MechanicalMCPError):
+    """Raised when Mechanical or a dependent service cannot complete an operation."""
+
+    error_code = "upstream_error"

--- a/src/ansys/mechanical/mcp/helpers.py
+++ b/src/ansys/mechanical/mcp/helpers.py
@@ -344,7 +344,7 @@ def list_instances(
     return str(tabulate(table, headers))
 
 
-def get_info(mechanical: "Mechanical") -> dict[str, str | dict[str, Any]]:
+def get_info(mechanical: "Mechanical") -> dict[str, Any]:
     """
     Get information from the Mechanical instance.
 

--- a/src/ansys/mechanical/mcp/mechanical_helper/startup_code.py
+++ b/src/ansys/mechanical/mcp/mechanical_helper/startup_code.py
@@ -22,6 +22,7 @@ loaded when the persistent Python session starts.
 
 import base64
 from io import BytesIO, TextIOWrapper
+import os
 import sys
 
 # Set UTF-8 encoding for stdout and stderr to handle Unicode characters
@@ -30,35 +31,42 @@ if sys.stdout.encoding != "utf-8":
 if sys.stderr.encoding != "utf-8":
     sys.stderr = TextIOWrapper(sys.stderr.buffer, encoding="utf-8", errors="replace")
 
-# Matplotlib is optional; needed only for create_custom_plot
-try:
-    import matplotlib
-    import matplotlib.pyplot as plt
+# Configure optional plotting packages only when a plotting helper is called.
+# Starting a plotting/VTK stack during the MCP initialize handshake can delay
+# clients that never request a custom plot. This environment setting also makes
+# user code that imports pyplot use a non-interactive backend in headless hosts.
+os.environ.setdefault("MPLBACKEND", "Agg")
+os.environ.setdefault("PYVISTA_OFF_SCREEN", "true")
 
-    matplotlib.use("Agg")
-    MATPLOTLIB_AVAILABLE = True
-except ImportError:
-    MATPLOTLIB_AVAILABLE = False
 
-# Optional: Try to import PyVista for 3D visualization
-try:
-    from PIL import Image
-    import pyvista as pv
+def _load_matplotlib():
+    """Load Matplotlib with the non-interactive backend selected first."""
+    try:
+        import matplotlib
 
-    # Enable off-screen rendering globally
-    pv.OFF_SCREEN = True
+        matplotlib.use("Agg", force=True)
+        import matplotlib.pyplot as plt
 
-    # Set a clean default theme
-    pv.set_plot_theme("document")
+        return plt
+    except Exception:
+        return None
 
-    PYVISTA_AVAILABLE = True
-except ImportError:
-    PYVISTA_AVAILABLE = False
+
+def _load_pyvista():
+    """Load PyVista only when a three-dimensional plot is requested."""
+    try:
+        from PIL import Image
+        import pyvista as pv
+
+        pv.OFF_SCREEN = True
+        pv.set_plot_theme("document")
+        return Image, pv
+    except Exception:
+        return None, None
 
 
 def save_plot(plotter) -> str:
-    """
-    Save the PyVista plot to file and return as base64.
+    """Save the PyVista plot to file and return as base64.
 
     Parameters
     ----------
@@ -70,40 +78,26 @@ def save_plot(plotter) -> str:
     str
         Base64 data URI of the plot.
     """
-    if not PYVISTA_AVAILABLE:
+    image_module, _ = _load_pyvista()
+    if image_module is None:
         return "Error: PyVista is not available"
 
     try:
-        # Capture screenshot
         img_array = plotter.screenshot(return_img=True, transparent_background=False)
-
-        # Convert to PIL Image
-        img = Image.fromarray(img_array)
-
-        # Save to buffer
+        img = image_module.fromarray(img_array)
         buffer = BytesIO()
         img.save(buffer, format="PNG")
-
-        # Seek to beginning before reading
         buffer.seek(0)
-
-        # Encode to base64
         img_base64 = base64.b64encode(buffer.read()).decode("utf-8")
-
-        # Create data URI
-        result = f"data:image/png;base64,{img_base64}"
-
-        # Clean up and return
         plotter.close()
-        return result
+        return f"data:image/png;base64,{img_base64}"
     except Exception as e:
         plotter.close()
         return f"Error in save_plot: {str(e)}"
 
 
 def save_matplotlib_plot(dpi=150):
-    """
-    Return the current Matplotlib plot as a base64-encoded PNG image.
+    """Return the current Matplotlib plot as a base64-encoded PNG image.
 
     Parameters
     ----------
@@ -115,25 +109,14 @@ def save_matplotlib_plot(dpi=150):
     str
         Base64 data URI of the plot.
     """
-    if not MATPLOTLIB_AVAILABLE:
+    plt = _load_matplotlib()
+    if plt is None:
         return "Error: matplotlib is not available"
 
     buffer = BytesIO()
     plt.savefig(buffer, format="png", dpi=dpi, bbox_inches="tight")
     buffer.seek(0)
-
     img_base64 = base64.b64encode(buffer.read()).decode("utf-8")
     result = f"data:image/png;base64,{img_base64}"
     plt.close()
     return result
-
-
-# Print confirmation
-if MATPLOTLIB_AVAILABLE:
-    print("Matplotlib configured with non-interactive backend (Agg)")
-else:
-    print("Matplotlib not available (optional: install for custom plots)")
-if PYVISTA_AVAILABLE:
-    print("PyVista configured for off-screen rendering")
-else:
-    print("PyVista not available (optional)")

--- a/src/ansys/mechanical/mcp/tools.py
+++ b/src/ansys/mechanical/mcp/tools.py
@@ -23,7 +23,7 @@ import os
 from pathlib import Path
 import re
 import tempfile
-from typing import Any
+from typing import Any, cast
 
 # Import Mechanical at module level to avoid import during tool execution
 # The import happens during server startup, before STDIO transport is active
@@ -33,6 +33,7 @@ from fastmcp.server.server import get_logger
 
 from ansys.mechanical import core as pymechanical  # pyright: ignore[reportMissingTypeStubs]
 from ansys.mechanical.mcp import app
+from ansys.mechanical.mcp.errors import InvalidArgumentsError, NotConnectedError, UpstreamError
 from ansys.mechanical.mcp.helpers import (
     _is_docker,
     _probe_grpc_endpoint,
@@ -50,6 +51,47 @@ logger = get_logger(__name__)
 # These tools are disabled at startup (before Mechanical is connected) and enabled
 # once a connection is established via connect_to_mechanical or launch_mechanical.
 REQUIRES_MECHANICAL_TAG = "requires_mechanical"
+
+
+def _structured_error(error: NotConnectedError | InvalidArgumentsError | UpstreamError) -> str:
+    """Serialize a known tool error for clients that can handle structured results."""
+    logger.info("%s: %s", error.error_code, error.message)
+    return json.dumps(error.to_dict(), ensure_ascii=False)
+
+
+def _mechanical_or_error(ctx: Context) -> tuple[Any | None, str | None]:
+    """Return the active Mechanical session or a consistent structured error."""
+    mechanical = ctx.request_context.lifespan_context.mechanical
+    if mechanical is None:
+        return None, _structured_error(
+            NotConnectedError(
+                "No Mechanical connection available. Use connect_to_mechanical "
+                "to establish a connection."
+            )
+        )
+    return mechanical, None
+
+
+def _python_session_status(python_session: Any | None) -> dict[str, Any]:
+    """Return safe persistent-session state without allowing diagnostics to fail."""
+    if python_session is None:
+        return {"available": False, "running": False, "python_executable": None}
+
+    try:
+        running = bool(python_session.is_running())
+    except Exception as exc:
+        return {
+            "available": True,
+            "running": False,
+            "python_executable": getattr(python_session, "python_executable", None),
+            "error": str(exc),
+        }
+
+    return {
+        "available": True,
+        "running": running,
+        "python_executable": getattr(python_session, "python_executable", None),
+    }
 
 
 async def _resolve_launch_batch_mode(ctx: Context, batch: bool | None) -> bool:
@@ -117,13 +159,10 @@ def check_mechanical_status(ctx: Context) -> str:
 
         Returns an error message if Mechanical is not available or has exited.
     """
-    mechanical = ctx.request_context.lifespan_context.mechanical
-
-    if mechanical is None:
-        return (
-            "No Mechanical connection available. "
-            "Use connect_to_mechanical tool to establish a connection."
-        )
+    mechanical, error = _mechanical_or_error(ctx)
+    if error is not None:
+        return error
+    mechanical = cast(Any, mechanical)
 
     try:
         # Check if Mechanical has exited
@@ -131,14 +170,40 @@ def check_mechanical_status(ctx: Context) -> str:
             return "Mechanical instance has exited. Reconnect or launch a new instance."
 
         info = get_info(mechanical)
+        python_session = ctx.request_context.lifespan_context.python_session
+        info["python_session"] = _python_session_status(python_session)
 
         # Return as formatted JSON
-        return json.dumps(info, indent=2)
+        return json.dumps(info, indent=2, default=str)
 
     except Exception as e:
         error_msg = f"Error checking Mechanical status: {str(e)}"
         logger.error(error_msg)
         return error_msg
+
+
+@app.tool()
+def get_session_diagnostics(ctx: Context) -> str:
+    """Return safe connection and persistent-Python-session diagnostics.
+
+    This tool intentionally excludes environment variables, command histories,
+    tokens, and certificate paths. Use it when diagnosing an MCP setup issue
+    before sharing logs with a maintainer.
+    """
+    context = ctx.request_context.lifespan_context
+    python_session = context.python_session
+    mechanical = context.mechanical
+    return json.dumps(
+        {
+            "mechanical_connected": mechanical is not None,
+            "mechanical_alive": (
+                bool(getattr(mechanical, "is_alive", False)) if mechanical is not None else False
+            ),
+            "grpc_transport_mode": context.grpc_transport_mode,
+            "persistent_python": _python_session_status(python_session),
+        },
+        indent=2,
+    )
 
 
 @app.tool(tags={"aali"})
@@ -719,6 +784,56 @@ def download_file(ctx: Context, file_name: str, target_dir: str | None = None) -
         error_msg = f"Error downloading file: {str(e)}"
         logger.error(error_msg)
         return error_msg
+
+
+@app.tool(tags={REQUIRES_MECHANICAL_TAG})
+def download_project(
+    ctx: Context,
+    extensions: list[str] | None = None,
+    target_dir: str | None = None,
+) -> str:
+    """Download the connected Mechanical project's files as one operation.
+
+    Parameters
+    ----------
+    ctx : Context
+        MCP context containing the connected Mechanical instance.
+    extensions : list[str] | None, optional
+        Optional file extensions to include, such as ``["mechdb", "png"]``.
+        When omitted, downloads all project files supported by PyMechanical.
+    target_dir : str | None, optional
+        Local directory to receive the downloaded files. Uses the current
+        directory when omitted.
+
+    Returns
+    -------
+    str
+        JSON result containing the downloaded local paths or a structured error.
+    """
+    mechanical, error = _mechanical_or_error(ctx)
+    if error is not None:
+        return error
+    mechanical = cast(Any, mechanical)
+
+    if extensions is not None and any(not extension.strip() for extension in extensions):
+        return _structured_error(
+            InvalidArgumentsError("extensions must contain non-empty file-extension strings.")
+        )
+
+    try:
+        paths = mechanical.download_project(
+            extensions=extensions or [], target_dir=target_dir, progress_bar=False
+        )
+        return json.dumps(
+            {
+                "success": True,
+                "downloaded_files": [str(path) for path in paths],
+                "file_count": len(paths),
+            },
+            indent=2,
+        )
+    except Exception as exc:
+        return _structured_error(UpstreamError(f"Error downloading project: {exc}"))
 
 
 @app.tool(tags={REQUIRES_MECHANICAL_TAG})

--- a/src/ansys/mechanical/mcp/tools.py
+++ b/src/ansys/mechanical/mcp/tools.py
@@ -820,9 +820,15 @@ def download_project(
             InvalidArgumentsError("extensions must contain non-empty file-extension strings.")
         )
 
+    # Unlike Mechanical.download(), Mechanical.download_project() calls
+    # target_dir.rstrip(...) unconditionally and raises AttributeError when
+    # target_dir is None. Default to the current working directory to match
+    # the documented "uses the current directory when omitted" behavior.
+    resolved_target_dir = target_dir if target_dir is not None else str(Path.cwd())
+
     try:
         paths = mechanical.download_project(
-            extensions=extensions or [], target_dir=target_dir, progress_bar=False
+            extensions=extensions or [], target_dir=resolved_target_dir, progress_bar=False
         )
         return json.dumps(
             {

--- a/src/ansys/mechanical/mcp/toolsets.py
+++ b/src/ansys/mechanical/mcp/toolsets.py
@@ -54,6 +54,7 @@ _TOOLSET_CATALOGUE: dict[str, dict[str, Any]] = {
         "tools": [
             "check_mechanical_installed",
             "check_mechanical_status",
+            "get_session_diagnostics",
             "list_mechanical_instances",
             "launch_mechanical",
             "connect_to_mechanical",
@@ -105,6 +106,7 @@ _TOOLSET_CATALOGUE: dict[str, dict[str, Any]] = {
         "tools": [
             "upload_file",
             "download_file",
+            "download_project",
             "list_files",
         ],
     },

--- a/tests/test_helpers_additional.py
+++ b/tests/test_helpers_additional.py
@@ -162,10 +162,10 @@ def test_sanitize_output_replacements():
 def test_startup_code_error_paths(monkeypatch):
     from ansys.mechanical.mcp.mechanical_helper import startup_code
 
-    monkeypatch.setattr(startup_code, "MATPLOTLIB_AVAILABLE", False)
+    monkeypatch.setattr(startup_code, "_load_matplotlib", lambda: None)
     assert startup_code.save_matplotlib_plot() == "Error: matplotlib is not available"
 
-    monkeypatch.setattr(startup_code, "PYVISTA_AVAILABLE", False)
+    monkeypatch.setattr(startup_code, "_load_pyvista", lambda: (None, None))
     assert startup_code.save_plot(MagicMock()) == "Error: PyVista is not available"
 
 
@@ -180,8 +180,7 @@ def test_startup_code_save_matplotlib_plot_success(monkeypatch):
     fake_plt.savefig.side_effect = fake_plot.savefig
     fake_plt.close.return_value = None
 
-    monkeypatch.setattr(startup_code, "MATPLOTLIB_AVAILABLE", True)
-    monkeypatch.setattr(startup_code, "plt", fake_plt)
+    monkeypatch.setattr(startup_code, "_load_matplotlib", lambda: fake_plt)
     monkeypatch.setattr(startup_code, "BytesIO", lambda: buffer)
 
     result = startup_code.save_matplotlib_plot(dpi=200)
@@ -204,8 +203,7 @@ def test_startup_code_save_plot_success(monkeypatch):
     fake_plotter.screenshot.return_value = [1, 2, 3]
     fake_plotter.close.return_value = None
 
-    monkeypatch.setattr(startup_code, "PYVISTA_AVAILABLE", True)
-    monkeypatch.setattr(startup_code, "Image", fake_image_module)
+    monkeypatch.setattr(startup_code, "_load_pyvista", lambda: (fake_image_module, MagicMock()))
     monkeypatch.setattr(startup_code, "BytesIO", lambda: buffer)
     monkeypatch.setattr(startup_code.base64, "b64encode", lambda data: b"encoded")
 
@@ -215,6 +213,26 @@ def test_startup_code_save_plot_success(monkeypatch):
     fake_plotter.screenshot.assert_called_once_with(return_img=True, transparent_background=False)
     image.save.assert_called_once_with(buffer, format="PNG")
     fake_plotter.close.assert_called_once()
+
+
+def test_startup_code_defers_optional_plotting_imports():
+    from ansys.mechanical.mcp.mechanical_helper import startup_code
+
+    assert "matplotlib.pyplot" not in startup_code.__dict__
+    assert "pyvista" not in startup_code.__dict__
+
+
+def test_load_matplotlib_selects_agg_before_pyplot(monkeypatch):
+    from ansys.mechanical.mcp.mechanical_helper import startup_code
+
+    matplotlib = MagicMock()
+    pyplot = MagicMock()
+    matplotlib.pyplot = pyplot
+    monkeypatch.setitem(sys.modules, "matplotlib", matplotlib)
+    monkeypatch.setitem(sys.modules, "matplotlib.pyplot", pyplot)
+
+    assert startup_code._load_matplotlib() is pyplot
+    matplotlib.use.assert_called_once_with("Agg", force=True)
 
 
 def test_module_entrypoint_invokes_launcher(monkeypatch):

--- a/tests/test_project_download.py
+++ b/tests/test_project_download.py
@@ -1,0 +1,48 @@
+# Copyright (C) 2026 Synopsys, Inc. and ANSYS, Inc. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for project download tool behavior."""
+
+import json
+
+from ansys.mechanical.mcp.tools import download_project
+
+
+def test_download_project_success(mock_context):
+    mechanical = mock_context.request_context.lifespan_context.mechanical
+    mechanical.download_project.return_value = ["C:/output/project.mechdb"]
+
+    result = json.loads(
+        download_project(mock_context, extensions=["mechdb"], target_dir="C:/output")
+    )
+
+    assert result == {
+        "success": True,
+        "downloaded_files": ["C:/output/project.mechdb"],
+        "file_count": 1,
+    }
+    mechanical.download_project.assert_called_once_with(
+        extensions=["mechdb"], target_dir="C:/output", progress_bar=False
+    )
+
+
+def test_download_project_requires_connection(mock_context_no_mechanical):
+    result = json.loads(download_project(mock_context_no_mechanical))
+
+    assert result["error_code"] == "not_connected"
+
+
+def test_download_project_rejects_empty_extension(mock_context):
+    result = json.loads(download_project(mock_context, extensions=["mechdb", " "]))
+
+    assert result["error_code"] == "invalid_arguments"
+
+
+def test_download_project_returns_upstream_error(mock_context):
+    mechanical = mock_context.request_context.lifespan_context.mechanical
+    mechanical.download_project.side_effect = RuntimeError("transfer failed")
+
+    result = json.loads(download_project(mock_context))
+
+    assert result["error_code"] == "upstream_error"
+    assert "transfer failed" in result["error"]

--- a/tests/test_project_download.py
+++ b/tests/test_project_download.py
@@ -4,6 +4,7 @@
 """Tests for project download tool behavior."""
 
 import json
+from unittest.mock import ANY
 
 from ansys.mechanical.mcp.tools import download_project
 
@@ -30,6 +31,25 @@ def test_download_project_requires_connection(mock_context_no_mechanical):
     result = json.loads(download_project(mock_context_no_mechanical))
 
     assert result["error_code"] == "not_connected"
+
+
+def test_download_project_defaults_target_dir_to_cwd(mock_context):
+    """Mechanical.download_project() raises AttributeError when target_dir is None.
+
+    Regression test: the tool must resolve a concrete local directory before
+    calling the underlying PyMechanical API instead of forwarding ``None``.
+    """
+    mechanical = mock_context.request_context.lifespan_context.mechanical
+    mechanical.download_project.return_value = ["C:/cwd/project.mechdb"]
+
+    result = json.loads(download_project(mock_context))
+
+    assert result["success"] is True
+    mechanical.download_project.assert_called_once_with(
+        extensions=[], target_dir=ANY, progress_bar=False
+    )
+    called_target_dir = mechanical.download_project.call_args.kwargs["target_dir"]
+    assert called_target_dir is not None
 
 
 def test_download_project_rejects_empty_extension(mock_context):

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -30,6 +30,7 @@ from ansys.mechanical.mcp.tools import (
     disconnect_from_mechanical,
     download_file,
     get_model_info,
+    get_session_diagnostics,
     launch_mechanical,
     list_files,
     list_mechanical_instances,
@@ -69,7 +70,9 @@ class TestCheckMechanicalStatus:
 
         # Should return helpful error message instead of raising exception
         assert isinstance(result, str)
-        assert "No Mechanical connection available" in result
+        data = json.loads(result)
+        assert data["error_code"] == "not_connected"
+        assert "No Mechanical connection available" in data["error"]
         assert "connect_to_mechanical" in result
 
     def test_check_status_with_exited_mechanical(self, mock_context):
@@ -102,6 +105,56 @@ class TestCheckMechanicalStatus:
         assert "version" in data["connection"]
         assert "project_directory" in data["connection"]
         assert "is_alive" in data["connection"]
+
+    def test_check_status_includes_python_session_diagnostics(self, mock_context):
+        mock_context.request_context.lifespan_context.mechanical.exited = False
+        mock_context.request_context.lifespan_context.mechanical.busy = False
+        session = MagicMock()
+        session.is_running.return_value = True
+        session.python_executable = "python"
+        mock_context.request_context.lifespan_context.python_session = session
+
+        data = json.loads(check_mechanical_status(mock_context))
+
+        assert data["python_session"] == {
+            "available": True,
+            "running": True,
+            "python_executable": "python",
+        }
+
+
+@pytest.mark.unit
+class TestSessionDiagnostics:
+    def test_reports_connection_and_python_session_state(self, mock_context):
+        session = MagicMock()
+        session.is_running.return_value = True
+        session.python_executable = "C:/Python/python.exe"
+        mock_context.request_context.lifespan_context.python_session = session
+
+        data = json.loads(get_session_diagnostics(mock_context))
+
+        assert data["mechanical_connected"] is True
+        assert data["persistent_python"]["running"] is True
+        assert data["persistent_python"]["python_executable"] == "C:/Python/python.exe"
+
+    def test_reports_missing_python_session(self, mock_context):
+        mock_context.request_context.lifespan_context.python_session = None
+
+        data = json.loads(get_session_diagnostics(mock_context))
+
+        assert data["persistent_python"]["available"] is False
+        assert data["persistent_python"]["running"] is False
+
+    def test_handles_python_session_state_failure(self, mock_context):
+        session = MagicMock()
+        session.is_running.side_effect = RuntimeError("process unavailable")
+        session.python_executable = "python"
+        mock_context.request_context.lifespan_context.python_session = session
+
+        data = json.loads(get_session_diagnostics(mock_context))
+
+        assert data["persistent_python"]["running"] is False
+        assert data["persistent_python"]["error"] == "process unavailable"
 
 
 @pytest.mark.unit
@@ -1845,6 +1898,7 @@ class TestRequiresMechanicalVisibility:
         ALWAYS_AVAILABLE_TOOLS = {
             "check_mechanical_installed",
             "check_mechanical_status",
+            "get_session_diagnostics",
             "launch_mechanical",
             "connect_to_mechanical",
             "list_mechanical_instances",


### PR DESCRIPTION
## Summary
- Removes the product-local GHCR image-pull retry and restores standard Docker pull behavior; the original `TOOMANYREQUESTS` failure was a transient registry-side condition.
- Defers Matplotlib, Pillow, and PyVista/VTK initialization until a plotting helper is actually used, so MCP startup no longer imports the visualization stack.
- Forces Matplotlib's `Agg` backend before `pyplot` is imported and configures PyVista for off-screen rendering.
- Adds safe persistent-Python diagnostics to `check_mechanical_status` and a non-sensitive `get_session_diagnostics` tool.
- Adds `download_project`, using PyMechanical's public `Mechanical.download_project` API for bulk project retrieval.
- Bumps the package version to `0.2.1`, adds release notes, and documents the 23-tool surface.

## Error contract
- Uses narrow, JSON-serialized `not_connected`, `invalid_arguments`, and `upstream_error` responses only for new/updated diagnostic and project-download paths.
- Does not alter existing tool response contracts globally.

## Validation
- `uv run pytest -m "not integration" --no-cov -q` — 250 passed, 5 integration tests deselected.
- `uv run pytest -m integration --no-cov -q` — 5 passed against locally installed Mechanical 2026 R1.
- `uv run pre-commit run --all-files` — passed: Ruff, mypy, Bandit, YAML/TOML, headers, whitespace, and typos.
- `git diff --check` — passed.
- Direct MCP protocol validation through `FastMCP Client`: verified server initialization, tool visibility, `check_mechanical_installed`, `get_session_diagnostics`, `launch_mechanical`, `check_mechanical_status`, `run_python_code`, `run_python_script`, Matplotlib `create_custom_plot`, `list_files`, `get_model_info`, `get_mechanical_logs`, `disconnect_from_mechanical`, and the new `download_project` after saving an isolated temporary `.mechdb` file.
- All PR checks pass. The first remote integration attempt failed before tests while GHCR returned `TOOMANYREQUESTS` with a sub-second `retry-after`; rerun attempt 2 passed unchanged, confirming the documented transient registry condition without restoring product-local retry logic.

## Scope intentionally deferred
- A global typed-error/decorator conversion was not introduced because current tool contracts include strings and mixed text/image responses. This PR limits structured errors to compatibility-safe paths.